### PR TITLE
Initial support for user clustered workers

### DIFF
--- a/Cartridge
+++ b/Cartridge
@@ -3,3 +3,4 @@ github.com/onsi/gomega origin/master
 github.com/nu7hatch/gouuid origin/master
 github.com/pivotal-cf-experimental/cf-acceptance-tests/helpers origin/master
 github.com/vito/cmdtest origin/master
+github.com/garyburd/redigo/redis origin/master

--- a/Cartridge.lock
+++ b/Cartridge.lock
@@ -3,3 +3,4 @@ github.com/onsi/gomega	d7685fbd45fb7bef327b43ca2781368c68bf72b7
 github.com/nu7hatch/gouuid	179d4d0c4d8d407a32af483c2354df1d2c91e6c3
 github.com/pivotal-cf-experimental/cf-acceptance-tests/helpers	accec453e017a39c7d42459af8b110b8b19a88d3
 github.com/vito/cmdtest	a720969567219160e78fdf5f1486b6887771f311
+github.com/garyburd/redigo/redis	ed54f4ed86a815cf09870e4bd1a10a2ee39a4308

--- a/redis/redis_suite_test.go
+++ b/redis/redis_suite_test.go
@@ -1,0 +1,13 @@
+package redis_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestRedis(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Redis Suite")
+}

--- a/redis/slave.go
+++ b/redis/slave.go
@@ -1,0 +1,36 @@
+package redis
+
+import (
+	"github.com/garyburd/redigo/redis"
+	"strings"
+	"time"
+)
+
+type Slave struct {
+	in          Connection
+	out         Connection
+	channel     string
+	experiments map[string]func() (time.Duration, error)
+}
+
+func NewSlave(in Connection, out Connection, channel string) *Slave {
+	return &Slave{in, out, channel, make(map[string]func() (time.Duration, error))}
+}
+
+func (self *Slave) WithExperiment(name string, fn func() (time.Duration, error)) *Slave {
+	self.experiments[name] = fn
+	return self
+}
+
+func (self *Slave) Next() error {
+	message, err := redis.String(self.in.Do("BLPOP", self.channel))
+	if err != nil {
+		return err
+	}
+
+	task := strings.SplitN(message, ",", 2)
+
+	duration, _ := self.experiments[task[1]]()
+	self.out.Do("RPUSH", task[0], duration)
+	return nil
+}

--- a/redis/worker.go
+++ b/redis/worker.go
@@ -1,0 +1,27 @@
+package redis
+
+import (
+	"github.com/garyburd/redigo/redis"
+	"time"
+)
+
+type Connection interface {
+	Do(commandName string, args ...interface{}) (reply interface{}, err error)
+}
+
+type Worker struct {
+	out           Connection // NOTE(jz) - probably have to make sure this is pooled and not shared
+	in            Connection // NOTE(jz) - probably have to make sure this is pooled and not shared
+	channel       string
+	reply_channel string
+}
+
+func NewWorker(out Connection, in Connection, channel string, reply_channel string) *Worker {
+	return &Worker{out, in, channel, reply_channel}
+}
+
+func (self *Worker) Time(experiment string) (time.Duration, error) {
+	self.out.Do("RPUSH", self.channel, self.reply_channel, experiment)
+	nanos, err := redis.Int64(self.in.Do("BLPOP", self.reply_channel))
+	return time.Duration(nanos), err
+}

--- a/redis/worker_test.go
+++ b/redis/worker_test.go
@@ -1,0 +1,79 @@
+package redis_test
+
+import (
+	"fmt"
+	. "github.com/julz/pat/redis"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"time"
+)
+
+var _ = Describe("Redis", func() {
+	Describe("Stub", func() {
+		It("Sends messages to time a function remotely", func() {
+			out := &DummyOutputConnection{}
+			in := &DummyReplyConnection{}
+			NewWorker(out, in, "a-channel-name", "a-reply-channel").Time("foo")
+			Ω(out.Messages).Should(HaveLen(1))
+			Ω(out.Messages[0]).Should(Equal("RPUSH a-channel-name, a-reply-channel, foo"))
+		})
+
+		It("Returns the reply time received from the reply channel", func() {
+			out := &DummyOutputConnection{}
+			in := &DummyReplyConnection{"BLPOP", int64(2 * time.Second)}
+			time, err := NewWorker(out, in, "a-channel-name", "a-reply-channel").Time("foo")
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(time.Seconds()).Should(Equal(2.0))
+		})
+
+		PIt("Times out and sends an error if a response doesn't come back quickly enough", func() {
+		})
+	})
+
+	Describe("Slave", func() {
+		It("Loads tasks from the queue and times them", func() {
+			out := &DummyOutputConnection{}
+			in := &DummyReplyConnection{"BLPOP", "a-reply-channel,foo"}
+			slave := NewSlave(in, out, "a-channel-name").WithExperiment("foo", func() (time.Duration, error) {
+				return time.Second * 2, nil
+			})
+			err := slave.Next()
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(out.Messages).Should(HaveLen(1))
+			Ω(out.Messages[0]).Should(Equal("RPUSH a-reply-channel, 2s"))
+		})
+
+		PIt("Sends errors back over the channel", func() {})
+	})
+})
+
+type DummyOutputConnection struct {
+	Messages []string
+}
+
+type DummyReplyConnection struct {
+	op    string
+	reply interface{}
+}
+
+func (self *DummyOutputConnection) Do(op string, args ...interface{}) (reply interface{}, err error) {
+	self.Messages = append(self.Messages, op+" "+join(args))
+	return nil, nil
+}
+
+func (self *DummyReplyConnection) Do(op string, args ...interface{}) (reply interface{}, err error) {
+	if op == self.op {
+		return self.reply, nil
+	}
+	return 9, nil
+}
+
+func join(strings []interface{}) (result string) {
+	for i, s := range strings {
+		if i > 0 {
+			result = result + ", "
+		}
+		result = result + fmt.Sprintf("%v", s)
+	}
+	return result
+}


### PR DESCRIPTION
Adds a Worker interface with two implementations, LocalWorker runs the test in a Goroutine, redis.Worker send a redis message to trigger the benchmark on a remote node. redis.Slave has some code to pull tasks off the queue, benchmark them, and then reply via redis with the result of the benchmark. 

Can probably do this much better, e.g. with one reply connection feeding in results rather than a reply connection for each slave, but this is a start.
