### PR TITLE
Split out the test listener so it can be shared

### DIFF
--- a/cmdline.go
+++ b/cmdline.go
@@ -3,6 +3,7 @@ package pat
 import (
 	"fmt"
 	. "github.com/julz/pat/benchmarker"
+	"github.com/julz/pat/experiments"
 	"strings"
 	"time"
 )
@@ -16,59 +17,37 @@ func RunCommandLine(pushes int, concurrency int, silent bool) *Response {
 	result := make(chan time.Duration)
 	errors := make(chan error)
 	workers := make(chan int)
+	samples := make(chan *Sample)
+	go Track(samples, result, errors, workers)
 
-	go func(started time.Time, result chan time.Duration) {
-		var avg int64
-		var total int64
-		var n int64
-		var totalErrors int64
-		var lastError string
-		var lastPush int64
-		var worstPush int64
-		var running int
-		tick := time.Tick(1 * time.Second)
-		for {
-			select {
-			case r := <-result:
-				total = total + r.Nanoseconds()
-				n = n + 1
-				avg = total / n
-				lastPush = r.Nanoseconds()
-				if lastPush > worstPush {
-					worstPush = lastPush
-				}
-			case w := <-workers:
-				running = running + w
-			case e := <-errors:
-				totalErrors = totalErrors + 1
-				lastError = e.Error()
-			case <-tick:
-			}
+	// TODO(jz) move this out to a presenter
+	go func(samples chan *Sample, target int) {
+		for s := range samples {
 			if !silent {
 				fmt.Print("\033[2J\033[;H")
 				fmt.Println("\x1b[32;1mCloud Foundry Performance Acceptance Tests\x1b[0m")
 				fmt.Printf("Test underway.  Pushes: \x1b[36m%v\x1b[0m  Concurrency: \x1b[36m%v\x1b[0m\n", pushes, concurrency)
 				fmt.Println("┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄\n")
-				fmt.Printf("\x1b[36mTotal pushes\x1b[0m:    %v  \x1b[36m%v\x1b[0m / %v\n", bar(n, int64(pushes), 25), n, int64(pushes))
+				fmt.Printf("\x1b[36mTotal pushes\x1b[0m:    %v  \x1b[36m%v\x1b[0m / %v\n", bar(s.Total, int64(target), 25), s.Total, int64(target))
 				fmt.Println()
-				fmt.Printf("Latest Push\x1b[0m:     \x1b[36m%v\x1b[0m\n", lastPush)
-				fmt.Printf("Worst Push\x1b[0m:      \x1b[36m%v\x1b[0m\n", worstPush)
-				fmt.Printf("Average\x1b[0m:         \x1b[36m%v\x1b[0m\n", avg)
-				fmt.Printf("Total time\x1b[0m:      \x1b[36m%v\x1b[0m\n", total)
-				fmt.Printf("Wall time\x1b[0m:       \x1b[36m%v\x1b[0m\n", time.Since(started))
-				fmt.Printf("\x1b[1mRunning Workers\x1b[0m: \x1b[36m%v\x1b[0m\n", running)
+				fmt.Printf("Latest Push\x1b[0m:     \x1b[36m%v\x1b[0m\n", s.LastResult)
+				fmt.Printf("Worst Push\x1b[0m:      \x1b[36m%v\x1b[0m\n", s.WorstResult)
+				fmt.Printf("Average\x1b[0m:         \x1b[36m%v\x1b[0m\n", s.Average)
+				fmt.Printf("Total time\x1b[0m:      \x1b[36m%v\x1b[0m\n", s.TotalTime)
+				fmt.Printf("Wall time\x1b[0m:       \x1b[36m%v\x1b[0m\n", s.WallTime)
+				fmt.Printf("\x1b[1mRunning Workers\x1b[0m: \x1b[36m%v\x1b[0m\n", s.TotalWorkers)
 				fmt.Println()
 				fmt.Println("┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄\n")
-				if totalErrors > 0 {
-					fmt.Printf("Total errors: %d\n", totalErrors)
-					fmt.Printf("Last error: %v\n", lastError)
+				if s.TotalErrors > 0 {
+					fmt.Printf("Total errors: %d\n", s.TotalErrors)
+					fmt.Printf("Last error: %v\n", "")
 				}
 			}
 		}
-	}(time.Now(), result)
+	}(samples, pushes)
 
 	totalTime, _ := Time(func() error {
-		ExecuteConcurrently(concurrency, Repeat(pushes, Counted(workers, Timed(result, errors, push))))
+		ExecuteConcurrently(concurrency, Repeat(pushes, Counted(workers, Timed(result, errors, experiments.Dummy))))
 		return nil
 	})
 

--- a/experiment.go
+++ b/experiment.go
@@ -1,0 +1,59 @@
+package pat
+
+import (
+	"time"
+)
+
+type Sample struct {
+	Average      time.Duration
+	TotalTime    time.Duration
+	Total        int64
+	TotalErrors  int
+	TotalWorkers int
+	LastResult   time.Duration
+	LastError    error
+	WorstResult  time.Duration
+	WallTime     time.Time
+}
+
+type RunningExperiment struct {
+	results chan time.Duration
+	errors  chan error
+	workers chan int
+	samples chan *Sample
+}
+
+func Track(samples chan *Sample, results chan time.Duration, errors chan error, workers chan int) {
+	ex := &RunningExperiment{results, errors, workers, samples}
+	ex.run()
+}
+
+func (ex *RunningExperiment) run() {
+	var n int64
+	var totalTime time.Duration
+	var avg time.Duration
+	var lastError error
+	var lastResult time.Duration
+	var totalErrors int
+	var workers int
+	var worstResult time.Duration
+	for {
+		select {
+		case result := <-ex.results:
+			n = n + 1
+			totalTime = totalTime + result
+			avg = time.Duration(totalTime.Nanoseconds() / n)
+			lastResult = result
+			if result > worstResult {
+				worstResult = result
+			}
+		case e := <-ex.errors:
+			lastError = e
+			totalErrors = totalErrors + 1
+		case w := <-ex.workers:
+			workers = workers + w
+		}
+
+		ex.samples <- &Sample{avg, totalTime, n, totalErrors, workers, lastResult, lastError, worstResult, time.Now()}
+	}
+}

--- a/experiment_test.go
+++ b/experiment_test.go
@@ -1,0 +1,27 @@
+package pat
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"time"
+)
+
+var _ = Describe("Experiment", func() {
+	It("Calculates the running average", func() {
+		results := make(chan time.Duration)
+		errors := make(chan error)
+		workers := make(chan int)
+
+		samples := make(chan *Sample)
+		go Track(samples, results, errors, workers)
+		go func() { results <- 2 * time.Second }()
+		go func() { results <- 4 * time.Second }()
+		go func() { results <- 6 * time.Second }()
+
+		Ω((<-samples).Average).Should(Equal(2 * time.Second))
+		Ω((<-samples).Average).Should(Equal(3 * time.Second))
+		Ω((<-samples).Average).Should(Equal(4 * time.Second))
+	})
+
+	PIt("Worst, errors, workers etc.", func() {})
+})

--- a/experiments/gcf.go
+++ b/experiments/gcf.go
@@ -1,4 +1,4 @@
-package pat
+package experiments
 
 import (
 	"github.com/nu7hatch/gouuid"
@@ -6,12 +6,12 @@ import (
 	"time"
 )
 
-func dummy() error {
+func Dummy() error {
 	time.Sleep(3 * time.Second)
 	return nil
 }
 
-func push() error {
+func Push() error {
 	guid, _ := uuid.NewV4()
 	err := Cf("push", "pats-"+guid.String(), "patsapp", "-m", "64M", "-p", "assets/hello-world").ExpectOutput("App started")
 	return err

--- a/pat/main.go
+++ b/pat/main.go
@@ -1,24 +1,25 @@
 package main
 
 import (
-	"flag"
-	"fmt"
-	"github.com/julz/pat"
+  "flag"
+  "fmt"
+  "github.com/julz/pat"
+  "github.com/julz/pat/server"
 )
 
 func main() {
-	server := flag.Bool("server", false, "true to run the HTTP server interface")
-	pushes := flag.Int("pushes", 1, "number of pushes to attempt")
-	concurrency := flag.Int("concurrency", 1, "max number of pushes to attempt in parallel")
-	silent := flag.Bool("silent", false, "true to run the commands and print output the terminal")
-	flag.Parse()
+  useServer := flag.Bool("server", false, "true to run the HTTP server interface")
+  pushes := flag.Int("pushes", 1, "number of pushes to attempt")
+  concurrency := flag.Int("concurrency", 1, "max number of pushes to attempt in parallel")
+  silent := flag.Bool("silent", false, "true to run the commands and print output the terminal")
+  flag.Parse()
 
-	if *server == true {
-		fmt.Println("Starting in server mode")
-		pat.Serve()
-		pat.Bind()
-	} else {
-		resp := pat.RunCommandLine(*pushes, *concurrency, *silent)
-		fmt.Printf("\n\nTest Complete. Total Time: %d\n", resp.TotalTime)
-	}
+  if *useServer == true {
+    fmt.Println("Starting in server mode")
+    server.Serve()
+    server.Bind()
+  } else {
+    resp := pat.RunCommandLine(*pushes, *concurrency, *silent)
+    fmt.Printf("\n\nTest Complete. Total Time: %d\n", resp.TotalTime)
+  }
 }

--- a/pat_suite_test.go
+++ b/pat_suite_test.go
@@ -1,6 +1,7 @@
 package pat
 
 import (
+	"github.com/julz/pat/server"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -9,6 +10,6 @@ import (
 
 func TestPat(t *testing.T) {
 	RegisterFailHandler(Fail)
-	ServeWithArgs("/tmp/pats-acceptance-test-runs")
+	server.ServeWithArgs("/tmp/pats-acceptance-test-runs")
 	RunSpecs(t, "Pat Suite")
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1,15 +1,21 @@
-package pat
+package server
 
 import (
 	"encoding/json"
 	"fmt"
 	"github.com/julz/pat/benchmarker"
+	"github.com/julz/pat/experiments"
 	"github.com/julz/pat/history"
 	"net/http"
 	"reflect"
 	"strconv"
 	"time"
 )
+
+type Response struct {
+	TotalTime int64
+	Timestamp int64
+}
 
 func Serve() {
 	ServeWithArgs("historical-runs")
@@ -53,7 +59,7 @@ func handleList(ctx *context, w http.ResponseWriter, r *http.Request) (interface
 }
 
 func handlePush(ctx *context, w http.ResponseWriter, r *http.Request) (interface{}, error) {
-	totalTime, _ := benchmarker.Time(dummy)
+	totalTime, _ := benchmarker.Time(experiments.Dummy)
 	result := &Response{totalTime.Nanoseconds(), time.Now().UnixNano()}
 	return history.Save(ctx.baseDir, result, result.Timestamp)
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,4 +1,4 @@
-package pat_test
+package server_test
 
 import (
 	. "github.com/julz/pat"

--- a/system_test.go
+++ b/system_test.go
@@ -24,7 +24,6 @@ var _ = Describe("System", func() {
 		PIt("Should fail to push an app when not logged in and report an error", func() {})
 	})
 
-
 	Describe("Running PATs with a web API", func() {
 		BeforeEach(func() {
 			os.RemoveAll("/tmp/pats-acceptance-test-runs")


### PR DESCRIPTION
Bit of tidying and refactoring. Moved experiments and server in to their own packages, and pulled out the code in cmdline.go that was doing the running statistics into its own class (experiment.go). Hopefully this means we can share experiment.go between server and cmd line and get the web UI to be able to provide live results just like the command line does. This also should make it easy to save continuous samples during a test when we get to that feature. 
