### PR TITLE
Hide x-axis ticks in bar chart when # of workload is <10

### DIFF
--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -43,7 +43,7 @@ pat.experiment = function(refreshRate) {
       exports.csvUrl(data.CsvLocation)
       exports.refreshNow()
       })
-    }	
+    }
   }
 
   exports.view = function(url) {

--- a/ui/js/bar.js
+++ b/ui/js/bar.js
@@ -27,6 +27,14 @@ d3.custom.barchart = function(el) {
     xAxis = d3.svg.axis().scale(x).orient("bottom");
     yAxis = d3.svg.axis().scale(y).orient("left");
 
+    if (data.length < 10) {
+      var tickValues = [];
+      for (var i = 1; i <= data.length; i++) {
+        tickValues.push(i)
+      }
+      xAxis.tickValues(tickValues);
+    }
+
     var svg = d3.select(".barchart");
     svg.append("g").attr("class", "x axis").attr("transform", "translate(" + xOffset + "," + (h-yOffset) + ")").call(xAxis);
     svg.append("g").attr("class", "y axis").attr("transform", "translate(" + xOffset + ","+ yOffset + ")").call(yAxis);
@@ -50,8 +58,9 @@ d3.custom.barchart = function(el) {
 //    });
   }
 
-  barchart.xAxis_max = function() { return xAxis.scale().domain()[1]; }
-  barchart.yAxis_max = function() { return yAxis.scale().domain()[0]; }
+  barchart.xAxis_max_domain = function() { return xAxis.scale().domain()[1]; }
+  barchart.yAxis_max_domain = function() { return yAxis.scale().domain()[0]; }
+  barchart.xAxis_max_value = function() { return xAxis.tickValues()[xAxis.tickValues().length - 1]; }
 
   return barchart;
 }

--- a/ui/js/tests.js
+++ b/ui/js/tests.js
@@ -122,7 +122,7 @@ describe("Bar chart", function() {
     expect(d3.selectAll('rect.bar').size()).toBe(3);
   });
 
-  it("should show at least 10 tasks in the x-axis", function() {
+  it("should show at least able to show 10 workloads in the x-axis", function() {
     var svg = d3.selectAll(".barchart");
     var tasks = [];
 
@@ -130,10 +130,10 @@ describe("Bar chart", function() {
         tasks.push( {"LastResult" : 1 * sec} );
     }
     chart(tasks);
-    expect( chart.xAxis_max() ).toBe(10);
+    expect( chart.xAxis_max_domain() ).toBe(10);
   });
 
-  it("should scale and show >10 tasks in the x-axis if >10 tasks has been performed", function() {
+  it("should scale and show >10 workloads in the x-axis if >10 workloads has been performed", function() {
     var svg = d3.selectAll(".barchart");
     var tasks = [];
 
@@ -141,9 +141,19 @@ describe("Bar chart", function() {
         tasks.push( {"LastResult" : 1 * sec} );
     }
     chart(tasks);
-    expect( chart.xAxis_max() ).toBe(15);
+    expect( chart.xAxis_max_domain() ).toBe(15);
   });
 
+  it("should not show extra ticks in x-axis when # of workload is <10 ", function() {
+    var svg = d3.selectAll(".barchart");
+    var tasks = [];
+
+    for (var i = 0; i < 5; i ++) {
+        tasks.push( {"LastResult" : 1 * sec} );
+    }
+    chart(tasks);
+    expect( chart.xAxis_max_value() ).toBe(5);
+  });
 
   it("should show the maximum LastResult in seconds in the y-axis", function() {
     var svg = d3.selectAll(".barchart");
@@ -155,7 +165,7 @@ describe("Bar chart", function() {
       tasks.push( {"LastResult" : LastResult} );
     }
     chart(tasks);
-    expect( chart.yAxis_max() ).toBe(10);
+    expect( chart.yAxis_max_domain() ).toBe(10);
   });
 
 });


### PR DESCRIPTION
Currently the bar chart shows ticks 1 to 10 by default even if the # of workload is <10.

With this change, the default size of x-axis remain the same (10 workloads), but the chart will not show extra ticks in the x-axis when workload is <10.
