### PR TITLE
Added support for deploying PAT to CloudFoundry via a Go Buildpack

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,3 @@
+applications:
+- name: pat
+  command: pat -server

--- a/server/server.go
+++ b/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"os"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -13,6 +14,10 @@ import (
 	"github.com/julz/pat/experiments"
 	. "github.com/julz/pat/laboratory"
 	"github.com/julz/pat/store"
+)
+
+const (
+	PortVar = "VCAP_APP_PORT"
 )
 
 type Response struct {
@@ -46,11 +51,22 @@ func ServeWithLab(lab Laboratory) {
 	http.Handle("/", r)
 }
 
+
 func Bind() {
-	fmt.Println("Starting web ui on http://localhost:8080/ui/")
-	if err := http.ListenAndServe(":8080", nil); err != nil {
+	port := GetPort()	
+	fmt.Printf("Starting web ui on http://localhost:%s/ui/\n", port)
+	if err := http.ListenAndServe(":"+port, nil); err != nil {
 		fmt.Printf("ListenAndServe: %s\n", err)
 	}
+}
+
+func GetPort() string {
+	port := os.Getenv(PortVar)
+	if port == "" {
+		port = "8080"
+	}
+
+	return port
 }
 
 type listResponse struct {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"os"
 
 	. "github.com/julz/pat/experiment"
 	. "github.com/julz/pat/laboratory"
@@ -26,6 +27,10 @@ var _ = Describe("Server", func() {
 		lab.experiments = experiments
 		http.DefaultServeMux = http.NewServeMux()
 		ServeWithLab(lab)
+	})
+
+	AfterEach(func() {
+		os.Clearenv()
 	})
 
 	It("lists experiments", func() {
@@ -78,6 +83,17 @@ var _ = Describe("Server", func() {
 	It("Returns Location based on assigned experiment GUID", func() {
 		json := post("/experiments/")
 		Ω(json["Location"]).Should(Equal("/experiments/some-guid"))
+	})
+
+	It("Checks if VCAP_APP_PORT exists and returns the port if true", func() {
+		os.Setenv("VCAP_APP_PORT", "1234")
+		port := GetPort()
+		Ω(port).Should(Equal("1234"))
+	})
+
+	It("Defaults to listening on port 8080 if the VCAP_APP_PORT environment variable is not set", func() {
+			port := GetPort()
+			Ω(port).Should(Equal("8080"))
 	})
 })
 


### PR DESCRIPTION
Added check for VCAP_APP_PORT, default to port 8080 otherwise. Added manifest.yml file for deploying to CloudFoundry in server mode.

Made for use with the go buildpack at github.com/jberkhahn/cloudfoundry-go-buildpack.
