### PR TITLE
Implement interval tests from the web UI

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -84,6 +84,15 @@ func (ctx *context) handlePush(w http.ResponseWriter, r *http.Request) (interfac
 		concurrency = 1
 	}
 
+	interval, err := strconv.Atoi(r.FormValue("interval"))
+	if err != nil {
+		interval = 0
+	}
+	stop, err := strconv.Atoi(r.FormValue("stop"))
+	if err != nil {
+		stop = 0
+	}
+
 	workload := r.FormValue("workload")
 	if workload == "" {
 		workload = "push"
@@ -94,7 +103,10 @@ func (ctx *context) handlePush(w http.ResponseWriter, r *http.Request) (interfac
 	worker.AddExperiment("login", experiments.Dummy)
 	worker.AddExperiment("push", experiments.Push)
 	worker.AddExperiment("dummy", experiments.Dummy)
-	experiment, _ := ctx.lab.Run(NewRunnableExperiment(NewExperimentConfiguration(pushes, concurrency, 0, 0, worker, workload)))
+	experiment, _ := ctx.lab.Run(
+		NewRunnableExperiment(
+			NewExperimentConfiguration(
+				pushes, concurrency, interval, stop, worker, workload)))
 
 	return ctx.router.Get("experiment").URL("name", experiment.GetGuid())
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -57,6 +57,8 @@ var _ = Describe("Server", func() {
 		post("/experiments/")
 		Ω(lab.config.Iterations).Should(Equal(1))
 		Ω(lab.config.Concurrency).Should(Equal(1))
+		Ω(lab.config.Interval).Should(Equal(0))
+		Ω(lab.config.Stop).Should(Equal(0))
 		Ω(lab.config.Workload).Should(Equal("push"))
 	})
 
@@ -68,6 +70,16 @@ var _ = Describe("Server", func() {
 	It("Supports a 'concurrency' parameter", func() {
 		post("/experiments/?concurrency=3")
 		Ω(lab.config.Concurrency).Should(Equal(3))
+	})
+
+	It("Supports an 'interval' parameter", func() {
+		post("/experiments/?interval=3")
+		Ω(lab.config.Interval).Should(Equal(3))
+	})
+
+	It("Supports a 'stop' parameter", func() {
+		post("/experiments/?stop=3")
+		Ω(lab.config.Stop).Should(Equal(3))
 	})
 
 	It("Supports a 'workload' parameter", func() {

--- a/ui/index.html
+++ b/ui/index.html
@@ -96,6 +96,18 @@ body { padding: 8px; }
             <input type="number" class="form-control" id="inputConcurrency" name="inputConcurrency" placeholder="1" data-bind="value: numConcurrent">
           </div>
         </div>
+        <div class="form-group" data-bind="css: { 'has-error': numIntervalHasError }">
+          <label for="inputInterval" class="col-sm-2 control-label">Interval</label>
+          <div class="col-sm-6">
+            <input type="number" class="form-control" id="inputInterval" name="inputInterval" placeholder="0" data-bind="value: numInterval">
+          </div>
+        </div>
+        <div class="form-group" data-bind="css: { 'has-error': numStopHasError }">
+          <label for="inputStop" class="col-sm-2 control-label">Stop</label>
+          <div class="col-sm-6">
+            <input type="number" class="form-control" id="inputStop" name="inputStop" placeholder="0" data-bind="value: numStop">
+          </div>
+        </div>
         <div class="form-group">
           <div class="col-sm-offset-2 col-sm-10">
             <button data-bind="click: start, enable: formHasNoErrors" id="startbtn" type="submit" class="btn btn-primary navbar-btn"><span class="glyphicon glyphicon-play"></span> Start Experiment</button>

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -8,7 +8,7 @@ pat.experiment = function(refreshRate) {
   exports.url = ko.observable("")
   exports.csvUrl = ko.observable("")
   exports.data = ko.observableArray()
-  exports.config = { iterations: ko.observable(1), concurrency: ko.observable(1) }
+  exports.config = { iterations: ko.observable(1), concurrency: ko.observable(1), interval: ko.observable(0), stop: ko.observable(0) }
 
   var timer = null
 
@@ -31,7 +31,7 @@ pat.experiment = function(refreshRate) {
   exports.run = function() {
     exports.state("running")
     exports.data([])
-		$.post( "/experiments/", { "iterations": exports.config.iterations(), "concurrency": exports.config.concurrency(), "workload": $("#cmdSelect").val() }, function(data) {
+		$.post( "/experiments/", { "iterations": exports.config.iterations(), "concurrency": exports.config.concurrency(), "interval": exports.config.interval(), "stop": exports.config.stop(),  "workload": $("#cmdSelect").val() }, function(data) {
 			exports.url(data.Location)
 			exports.csvUrl(data.CsvLocation)
 			exports.refreshNow()
@@ -118,7 +118,11 @@ pat.view = function(experimentList, experiment) {
   this.numIterationsHasError = ko.computed(function() { return experiment.config.iterations() <= 0 })
   this.numConcurrent = experiment.config.concurrency
   this.numConcurrentHasError = ko.computed(function() { return experiment.config.concurrency() <= 0 })
-  this.formHasNoErrors = ko.computed(function() { return ! ( this.numIterationsHasError() | this.numConcurrentHasError() ) }, this)
+  this.numInterval = experiment.config.interval
+  this.numIntervalHasError = ko.computed(function() { return experiment.config.interval() < 0 })
+  this.numStop = experiment.config.stop
+  this.numStopHasError = ko.computed(function() { return experiment.config.stop() < 0 })
+  this.formHasNoErrors = ko.computed(function() { return ! ( this.numIterationsHasError() | this.numConcurrentHasError() | this.numIntervalHasError() | this.numStopHasError() ) }, this)
   this.previousExperiments = experimentList.experiments
   this.data = experiment.data
 

--- a/ui/js/tests.js
+++ b/ui/js/tests.js
@@ -3,7 +3,7 @@ describe("The view", function() {
   var experimentList
 
   beforeEach(function() {
-    experiment = { run: function() {}, url: ko.observable(""), state: ko.observable(""), view: function() {}, csvUrl: ko.observable(""), config: { iterations: ko.observable(1), concurrency: ko.observable(1)  } }
+    experiment = { run: function() {}, url: ko.observable(""), state: ko.observable(""), view: function() {}, csvUrl: ko.observable(""), config: { iterations: ko.observable(1), concurrency: ko.observable(1), interval: ko.observable(0), stop: ko.observable(0) } }
     experimentList = { experiments: [], refreshNow: function(){} }
     spyOn(experimentList, "refreshNow")
     spyOn(experiment, "view")
@@ -53,6 +53,18 @@ describe("The view", function() {
       v.numIterations(1)
       expect(v.numIterationsHasError()).toBe(false)
       expect(v.numConcurrentHasError()).toBe(true)
+      expect(v.formHasNoErrors()).toBe(false)
+    })
+
+    it("prevents interval being < 0", function() {
+      v.numInterval(-1)
+      expect(v.numIntervalHasError()).toBe(true)
+      expect(v.formHasNoErrors()).toBe(false)
+    })
+
+    it("prevents stop being < 0", function() {
+      v.numStop(-1)
+      expect(v.numStopHasError()).toBe(true)
       expect(v.formHasNoErrors()).toBe(false)
     })
   })


### PR DESCRIPTION
Implemented  interval tests via webui. Removed blocks in server.go fromaccessing the interval and stop fields from the config generated from the webui. Added ginkgo tests to test these fields. Added fields in
index.html to allow the user to select values for interval and stop, defaulting to 0. Added functions to app.js to package the input into the config that gets sent down. Added tests to test.js to ensure the values are within acceptable bounds.
