### PR TITLE
Fixing the incorrect throughput calculation

### DIFF
--- a/experiment/runner.go
+++ b/experiment/runner.go
@@ -184,11 +184,11 @@ func (ex *SamplableExperiment) Sample() {
 			}
 		case w := <-ex.workers:
 			workers = workers + w
-		case seconds := <-ex.ticks:
+		case _ = <-ex.ticks:
 			sampleType = ThroughputSample
 			for key, _ := range commands {
-				cmd := commands[key]
-				cmd.Throughput = float64(cmd.Count) / float64(seconds)
+				cmd := commands[key]								
+				cmd.Throughput = float64(cmd.Count) / cmd.TotalTime.Seconds()
 				commands[key] = cmd
 			}
 		}

--- a/experiment/runner_test.go
+++ b/experiment/runner_test.go
@@ -184,12 +184,12 @@ var _ = Describe("ExperimentConfiguration and Sampler", func() {
 
 		It("Calculates the throughput for a command every tick", func() {
 			go func() {
-				iteration <- IterationResult{0, []StepResult{StepResult{Command: "push"}}, nil}
-				iteration <- IterationResult{0, []StepResult{StepResult{Command: "push"}}, nil}
+				iteration <- IterationResult{0, []StepResult{StepResult{Command: "push", Duration: 1 * time.Second}}, nil}
+				iteration <- IterationResult{0, []StepResult{StepResult{Command: "push", Duration: 1 * time.Second}}, nil}
 				ticks <- 2
-				iteration <- IterationResult{0, []StepResult{StepResult{Command: "push"}}, nil}
+				iteration <- IterationResult{0, []StepResult{StepResult{Command: "push", Duration: 1 * time.Second}}, nil}
 				ticks <- 3
-				iteration <- IterationResult{0, []StepResult{StepResult{Command: "push"}}, nil}
+				iteration <- IterationResult{0, []StepResult{StepResult{Command: "push", Duration: 3 * time.Second}}, nil}
 				ticks <- 6
 			}()
 


### PR DESCRIPTION
Current throughput is calculated by command_count/experiment_total_running_time, so with a workload such as "login, push, list", all the commands will end up having the same incorrect throughput value 

To correct this, the throughput calculation is now command_count/command_total_duration, so each command will have it's own correct throughput value.
