### PR TITLE
Fixed default gcfpush workload to use os-independent paths

### DIFF
--- a/workloads/gcf.go
+++ b/workloads/gcf.go
@@ -37,7 +37,8 @@ func DummyWithErrors() error {
 
 func Push() error {
 	guid, _ := uuid.NewV4()
-	err := Cf("push", "pats-"+guid.String(), "patsapp", "-m", "64M", "-p", "assets/hello-world").ExpectOutput("App started")
+	pathToApp := path.Join("assets", "hello-world")
+	err := Cf("push", "pats-"+guid.String(), "patsapp", "-m", "64M", "-p", pathToApp).ExpectOutput("App started")
 	return err
 }
 


### PR DESCRIPTION
Bugfix associated with previous pull request to push unique apps. The regular gcf:push command was assuming a unix-style directory structure. Changed push in workloads/gcf.go to use path.Join() to generate os-independent paths to the app to be pushed. 
