### PR TITLE
small update to address firefox bug

### DIFF
--- a/ui/js/bar.js
+++ b/ui/js/bar.js
@@ -96,6 +96,8 @@ d3_workload = function() {
   } //end initDOM
 
   var drawGraph = function(data) {
+    if (!data[0]) return;
+
     const second = 1000000000;
     var len = data.length;
     x = x.domain( [1, len, 1] ).range([barWidth + 1, len * (barWidth + 1)]);
@@ -193,7 +195,14 @@ d3_workload = function() {
   }
 
   function getNodeWidth(node) {
-    return node.getBBox().width;
+    //using a try..catch block to get around the Firefox bug, getBBox() fails if svg element is not rendered (display = none)
+    //https://bugzilla.mozilla.org/show_bug.cgi?id=612118
+    try {
+      return node.getBBox().width;
+    }
+    catch(err) {
+      return 0
+    }
   }
 
   function transformChart(node, x, y) {

--- a/ui/js/tests.js
+++ b/ui/js/tests.js
@@ -192,7 +192,7 @@ describe("Throughput chart", function() {
                     { Commands: { "login": {"Count": 3, "Throughput": 0.6}}}];
 
     var scaleX = d3.scale.linear().domain([0, workload.length]).range([0, svgWidth]);
-    var scaleY = d3.scale.linear().domain([0.6, 0]).range([0, svgHeight]);
+    var scaleY = d3.scale.linear().domain([0.6, 0]).range([10, svgHeight]);
 
     chart(workload);
 
@@ -235,7 +235,7 @@ describe("Throughput chart", function() {
     expect (color2).not.toEqual(color3)
   })
 
-  it("it should show tooltips of throughput values when mouse hover over a line", function() {
+  it("it should show colored tooltips of throughput values when mouse hover over a line", function() {
     var workload = [{ Commands: { "login": {"Count": 1, "Throughput": 0.50}}}, 
                     { Commands: { "login": {"Count": 2, "Throughput": 0.30}}},
                     { Commands: { "login": {"Count": 3, "Throughput": 0.60}}}];
@@ -249,6 +249,9 @@ describe("Throughput chart", function() {
     expect( $(node).find("g.datalogin text")[0].innerHTML ).toEqual("0.50")
     expect( $(node).find("g.datalogin text")[1].innerHTML ).toEqual("0.30")
     expect( $(node).find("g.datalogin text")[2].innerHTML ).toEqual("0.60")
+
+    var color = $(node).find("path.line")[0].getAttribute("stroke");
+    expect( $(node).find("g.datalogin circle")[0].getAttribute("fill") ).toEqual(color)
   })
 
   it("should show the maximum command throughput in seconds in the y-axis", function() {
@@ -316,6 +319,15 @@ describe("Bar chart", function() {
     var totalBars = $( node ).find("rect.bar").length;
     expect( totalBars ).toBe(3);
   });
+
+  it("should not draw a graph if data is empty", function(){
+    $(chartArea).empty();
+    var data = [];
+    chart(data);
+
+    var totalBars = $( node ).find("rect.bar").length;
+    expect( totalBars ).toBe(0);
+  })
 
   it("should show the maximum LastResult in seconds in the y-axis", function() {
     var LastResult = 0;

--- a/ui/js/throughput.js
+++ b/ui/js/throughput.js
@@ -1,7 +1,7 @@
 d3_throughput = function() {
   var margin = {top: 50, right: 30, bottom: 30, left: 30};  
   var svgWidth, svgHeight, jqObj, d3Obj, drawArea;
-  var x, y, xAxis, yAxis, svg, graphBox;
+  var x, y, xAxis, yAxis, svg, graphBox, color;
 
   var d3Graph = document.createElement('div');
   d3Graph.className = "throughputContainer";
@@ -16,7 +16,7 @@ d3_throughput = function() {
     svgWidth = jqObj.width() - margin.left - margin.right;
     svgHeight = jqObj.height() - margin.top - margin.bottom;
     x = d3.scale.linear().range([0, svgWidth], 1);
-    y = d3.scale.linear().domain([1,0]).range([0, svgHeight], 1);
+    y = d3.scale.linear().domain([1,0]).range([10, svgHeight], 1);
     color = d3.scale.category10();
 
     xAxis = d3.svg.axis()
@@ -113,7 +113,7 @@ d3_throughput = function() {
         .attr("class", "line")
         .attr("d", function(d, i) {return line(d.throughput); })
         .style("stroke", function (d) { return color(d.cmd) })  
-        .on("mouseover", function(d){ drawToolTip(d) })      
+        .on("mouseover", function(d){ drawToolTip(d, color(d.cmd)) })      
         .on("mouseout", function(d) { svg.selectAll("g.data" + d.cmd).remove() })
 
     var l = legend.enter()
@@ -164,21 +164,22 @@ d3_throughput = function() {
 
   } //end drawGraph
 
-  function drawToolTip(d) {
+  function drawToolTip(d, c) {
+    const pointRadis = 13;
+    const yOffset = 4;
     var tooptip = svg.selectAll("g.data" + d.cmd).data(d.throughput).enter()
       .append("g")
       .attr("class", "data" + d.cmd)
     tooptip.append("circle")        
-        .style("fill", "#333")
+        .style("fill", c)
         .attr("class", d.cmd)
         .attr("cx", function(d, i){ return x(i) })
         .attr("cy", function(d){ return y(d) })
-        .attr("r", function(d, i) { return i?15:0 })
+        .attr("r", pointRadis);
     tooptip.append("text")
-        .attr("dx", function(d,i){ return x(i) })
-        .attr("dy", function(d){ return y(d)+4 })
-        .attr("stroke", "white")
-        .attr("stroke-width", "1px")
+        .attr("x", function(d,i){ return x(i) })
+        .attr("y", function(d){ return y(d) + yOffset })
+        .style("fill", "white")
         .text(function(d){ return parseFloat(d).toFixed(2) })
   }
 


### PR DESCRIPTION
- There is a bug in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=612118) causing the chart to crash if SVG element is not rendered (display=none).  I have added a try..catch to get around the bug.
- Also gave the line chart a little headroom in the y-axis for nicer rendering
- changed svg text 'dx' to 'x' for Firefox rendering, tested in Firefox, Chrome and Safari
- popup tooltip in line chart is colored the same as the line now
- reduced tooltip size
