### PR TITLE
remove tooltip illegal character

### DIFF
--- a/ui/js/tests.js
+++ b/ui/js/tests.js
@@ -254,6 +254,18 @@ describe("Throughput chart", function() {
     expect( $(node).find("g.datalogin circle")[0].getAttribute("fill") ).toEqual(color)
   })
 
+  it("should replace illegal characters with underscore in tooltip class names", function() {
+    var illegalName = "gcf:login+123";
+    var workload = [{ Commands: { illegalName: {"Count": 1, "Throughput": 0.50}}}];
+
+    chart(workload);
+    d3.select(node).select("path.line").on("mouseover")({cmd: illegalName, throughput:[0.50]});
+
+    expect( $(node).find("g.data" + illegalName).length ).toEqual(0);
+        
+    expect( $(node).find("g.data" + "gcf_login_123").length ).toEqual(1);
+  })  
+
   it("should show the maximum command throughput in seconds in the y-axis", function() {
     var workload = [{ Commands: {
         "login": {"Throughput": 0.5}, 

--- a/ui/js/throughput.js
+++ b/ui/js/throughput.js
@@ -114,7 +114,7 @@ d3_throughput = function() {
         .attr("d", function(d, i) {return line(d.throughput); })
         .style("stroke", function (d) { return color(d.cmd) })  
         .on("mouseover", function(d){ drawToolTip(d, color(d.cmd)) })      
-        .on("mouseout", function(d) { svg.selectAll("g.data" + d.cmd).remove() })
+        .on("mouseout", function(d) { svg.selectAll("g.data" + d.cmd.replace(/[^a-zA-Z0-9]/g,"_")).remove() })
 
     var l = legend.enter()
       .append("g")
@@ -167,12 +167,13 @@ d3_throughput = function() {
   function drawToolTip(d, c) {
     const pointRadis = 13;
     const yOffset = 4;
-    var tooptip = svg.selectAll("g.data" + d.cmd).data(d.throughput).enter()
+    var className = d.cmd.replace(/[^a-zA-Z0-9]/g,"_");
+    var tooptip = svg.selectAll("g.data" + className).data(d.throughput).enter()
       .append("g")
-      .attr("class", "data" + d.cmd)
+      .attr("class", "data" + className)
     tooptip.append("circle")        
         .style("fill", c)
-        .attr("class", d.cmd)
+        .attr("class", className)
         .attr("cx", function(d, i){ return x(i) })
         .attr("cy", function(d){ return y(d) })
         .attr("r", pointRadis);


### PR DESCRIPTION
Currently throughput tooltip uses command name as class name, and it might contain illegal characters (e.g. gcf:push).

This change make sure illegal character will not end up in class name
no test provided because I don't think it is necessary to test logic within private methods
