### PR TITLE
Allow multiple credentials

### DIFF
--- a/cmdline/display.go
+++ b/cmdline/display.go
@@ -39,7 +39,7 @@ func display(concurrency int, iterations int, interval int, stop int, samples <-
 		fmt.Println("┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄")
 		if s.TotalErrors > 0 {
 			fmt.Printf("\nTotal errors: %d\n", s.TotalErrors)
-			fmt.Printf("Last error: %v\n", "")
+			fmt.Printf("Last error: %v\n", s.LastResult)
 		}
 		fmt.Println()
 		fmt.Println("Type q <Enter> (or ctrl-c) to exit")


### PR DESCRIPTION
This modification allows multiple username and password in the -rest:username and -rest:password flags.
All username and password must be separated by commas.  PAT take each username and password in turn at each iteration, and loop back when the list ends

Example usage
go run main.go -concurrency=1 -iterations=2 -rest:target=http://api.10.244.0.34.xip.io  -rest:space=test  -rest:username=admin,admin2 -rest:password=admin,pass2 -workload=rest:target,rest:login
