### PR TITLE
Allow multiple credentials

### DIFF
--- a/benchmarker/local.go
+++ b/benchmarker/local.go
@@ -15,10 +15,11 @@ func NewLocalWorker() *LocalWorker {
 	return &LocalWorker{defaultWorker{make(map[string]workloads.WorkloadStep)}}
 }
 
-func (self *LocalWorker) Time(experiment string) (result IterationResult) {
+func (self *LocalWorker) Time(experiment string, workerIndex int) (result IterationResult) {	
 	experiments := strings.Split(experiment, ",")
 	var start = time.Now()
 	context := make(map[string]interface{})
+	context["workerIndex"] = workerIndex
 	for _, e := range experiments {
 		stepTime, err := Time(func() error { return self.Experiments[e].Fn(context) })
 		result.Steps = append(result.Steps, StepResult{e, stepTime})

--- a/benchmarker/local_test.go
+++ b/benchmarker/local_test.go
@@ -2,10 +2,10 @@ package benchmarker
 
 import (
 	"errors"
-	"time"
 	. "github.com/cloudfoundry-community/pat/workloads"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"time"
 )
 
 var _ = Describe("LocalWorker", func() {
@@ -13,21 +13,21 @@ var _ = Describe("LocalWorker", func() {
 		It("Times a function by name", func() {
 			worker := NewLocalWorker()
 			worker.AddWorkloadStep(Step("foo", func() error { time.Sleep(1 * time.Second); return nil }, ""))
-			result := worker.Time("foo")
+			result := worker.Time("foo", 0)
 			Ω(result.Duration.Seconds()).Should(BeNumerically("~", 1, 0.1))
 		})
 
 		It("Sets the function command name in the response struct", func() {
 			worker := NewLocalWorker()
 			worker.AddWorkloadStep(Step("foo", func() error { time.Sleep(1 * time.Second); return nil }, ""))
-			result := worker.Time("foo")
+			result := worker.Time("foo", 0)
 			Ω(result.Steps[0].Command).Should(Equal("foo"))
 		})
 
 		It("Returns any errors", func() {
 			worker := NewLocalWorker()
 			worker.AddWorkloadStep(Step("foo", func() error { return errors.New("Foo") }, ""))
-			result := worker.Time("foo")
+			result := worker.Time("foo", 0)
 			Ω(result.Error).Should(HaveOccurred())
 		})
 
@@ -36,7 +36,7 @@ var _ = Describe("LocalWorker", func() {
 			worker := NewLocalWorker()
 			worker.AddWorkloadStep(StepWithContext("foo", func(ctx map[string]interface{}) error { context = ctx; ctx["a"] = 1; return nil }, ""))
 			worker.AddWorkloadStep(StepWithContext("bar", func(ctx map[string]interface{}) error { ctx["a"] = ctx["a"].(int) + 2; return nil }, ""))
-			worker.Time("foo")
+			worker.Time("foo", 0)
 			Ω(context).Should(HaveKey("a"))
 		})
 	})
@@ -49,7 +49,7 @@ var _ = Describe("LocalWorker", func() {
 			worker = NewLocalWorker()
 			worker.AddWorkloadStep(Step("foo", func() error { time.Sleep(1 * time.Second); return nil }, ""))
 			worker.AddWorkloadStep(Step("bar", func() error { time.Sleep(1 * time.Second); return nil }, ""))
-			result = worker.Time("foo,bar")
+			result = worker.Time("foo,bar", 0)
 		})
 
 		It("Reports the total time", func() {
@@ -78,7 +78,7 @@ var _ = Describe("LocalWorker", func() {
 			worker.AddWorkloadStep(Step("foo", func() error { time.Sleep(1 * time.Second); return nil }, ""))
 			worker.AddWorkloadStep(Step("bar", func() error { time.Sleep(1 * time.Second); return nil }, ""))
 			worker.AddWorkloadStep(Step("errors", func() error { return errors.New("fishfinger system overflow") }, ""))
-			result = worker.Time("foo,errors,bar")
+			result = worker.Time("foo,errors,bar", 0)
 		})
 
 		It("Records the error", func() {

--- a/benchmarker/worker.go
+++ b/benchmarker/worker.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Worker interface {
-	Time(experiment string) IterationResult
+	Time(experiment string, workerIndex int) IterationResult
 	AddWorkloadStep(workloads workloads.WorkloadStep)
 	Visit(fn func(workloads.WorkloadStep))
 	Validate(name string) (result bool, err error)

--- a/experiment/runner.go
+++ b/experiment/runner.go
@@ -120,7 +120,7 @@ func (config *RunnableExperiment) Run(tracker func(<-chan *Sample)) error {
 }
 
 func (ex *ExecutableExperiment) Execute() {
-	Execute(RepeatEveryUntil(ex.Interval, ex.Stop, func() {
+	Execute(RepeatEveryUntil(ex.Interval, ex.Stop, func(int) {
 		ExecuteConcurrently(ex.Concurrency, Repeat(ex.Iterations, Counted(ex.workers, TimedWithWorker(ex.iteration, ex.Worker, ex.Workload))))
 	}, ex.quit))
 


### PR DESCRIPTION
This modification allows multiple username and password in the -rest:username and -rest:password flags.
All username and password must be separated by commas. PAT take each username and password in turn at each iteration, and loop back when the list ends

Example usage
go run main.go -concurrency=1 -iterations=2 -rest:target=http://api.10.244.0.34.xip.io -rest:space=test -rest:username=admin,admin2 -rest:password=admin,pass2 -workload=rest:target,rest:login
