### PR TITLE
make sure legend text is updated with new commands

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -94,7 +94,7 @@ body { padding: 8px; }
           <div class="col-sm-6">
             <select id="cmdSelect" name="inputExperiment" class="form-control">
               <option value="gcf:push">Simple Push</option>
-              <option value="dummy,dummyWithErrors">Dummies (dummy, dummyWithErrors)</option>              
+              <option value="dummy,dummyWithErrors">Dummies (dummy, dummyWithErrors)</option>            
               <option value="dummy">Dummy Push</option>
       	      <option value="gcf:push,gcf:push">Multiple Pushes</option>
               <option value="dummyWithErrors">Dummy with Errors</option>

--- a/ui/js/tests.js
+++ b/ui/js/tests.js
@@ -306,7 +306,50 @@ describe("Throughput chart", function() {
     }
 
     expect( tickMax ).toBeCloseTo(3, tickSize);
-  });    
+  });
+
+  it("should draw legend in the same color of it's corresponding line", function() {
+    var workload = [{ Commands: {
+        "list": {"Throughput": 0.5}
+      } }];
+
+    chart(workload);
+
+    var color = $(node).find("path.line")[0].style.stroke    
+    expect( $(node).find("g.tplegend rect")[0].style.fill ).toEqual(color)
+  })
+
+  it("should show legend to indicate what command the lines are representing", function() {
+    var workload = [{ Commands: {
+        "login": {"Throughput": 0.5}, 
+        "push":  {"Throughput": 0.1}
+      } }];
+
+    chart(workload);
+
+    expect( $(node).find("g.tplegend").length ).toEqual(2);      
+  })
+
+  it("should show updated legend when new command is used in a experiment", function() {
+    var workload = [{ Commands: {
+        "login": {"Throughput": 0.5}, 
+        "push":  {"Throughput": 0.1}
+      } }];
+
+    chart(workload);
+
+    expect( $(node).find("g.tplegend text")[0].innerHTML ).toEqual("login")
+    expect( $(node).find("g.tplegend text")[1].innerHTML ).toEqual("push")
+
+    workload = [{ Commands: { "list": {"Throughput": 0.2} }}];
+    
+    chart(workload);
+    
+    setTimeout(function () {
+      expect( $(node).find("g.tplegend text")[0].innerHTML ).toEqual("list")
+      expect( $(node).find("g.tplegend text")[1].innerHTML ).toEqual(null)
+    }, 800);    
+  })
 
 })
 

--- a/ui/js/throughput.js
+++ b/ui/js/throughput.js
@@ -119,22 +119,26 @@ d3_throughput = function() {
     var l = legend.enter()
       .append("g")
         .attr("class", "tplegend")
-    
+
+    legend.transition()
+      .select("g.tplegend text")
+        .text(function(d){ return d.cmd }) 
+
     l.append("rect")
       .attr("x", 30)
       .attr("y", function(d, i) { return i * 15 + 2} )
       .attr("height", 10)
       .attr("width", 55)
-      .attr("fill", function(d) { return color(d.cmd) })
+      .style("fill", function(d) { return color(d.cmd) })
     l.append("text")
       .attr("x", 90 )
       .attr("y", function(d, i) { return i * 15 + 3 } )
       .attr("dy", ".7em")
-      .attr("stroke", function(d) { return color(d.cmd) })
+      .style("stroke", function(d) { return color(d.cmd) })
       .attr("stroke-width", "1px")
       .attr("style", "text-anchor: start;")
-      .text(function(d){ return d.cmd })
-      
+      .text(function(d){ return d.cmd }) 
+
     lineChart.exit().remove();
     legend.exit().remove();    
 


### PR DESCRIPTION
Currently the legend text stays even after user run a new experiment with a different command.

This change make sure the chart legend text is updated with the correct command text 
