### PR TITLE
Go steno!

### DIFF
--- a/Cartridge
+++ b/Cartridge
@@ -5,4 +5,5 @@ github.com/vito/cmdtest origin/master
 github.com/pivotal-cf-experimental/cf-test-helpers/cf origin/master
 github.com/gorilla/mux origin/master
 github.com/garyburd/redigo/redis origin/master
+github.com/cloudfoundry/gosteno origin/master
 launchpad.net/goyaml last:1

--- a/Cartridge.lock
+++ b/Cartridge.lock
@@ -5,4 +5,5 @@ github.com/vito/cmdtest	4b86f8c2259c55e86e4b971cd7dc5dfb03e41b80
 github.com/pivotal-cf-experimental/cf-test-helpers/cf	430a0c8fc34acb4e09e54c22b61c0cd07311a262
 github.com/gorilla/mux	9ede152210fa25c1377d33e867cb828c19316445
 github.com/garyburd/redigo/redis	ed54f4ed86a815cf09870e4bd1a10a2ee39a4308
+github.com/cloudfoundry/gosteno	5eb8c6e554f0dfc39d6468813b8ac19ec28fe74f
 launchpad.net/goyaml	51

--- a/benchmarker/redis.go
+++ b/benchmarker/redis.go
@@ -33,7 +33,6 @@ func (rw rw) Time(experiment string, workerIndex int) (result IterationResult) {
 	reply, err := redis.Strings(rw.conn.Do("BLPOP", "replies-"+guid.String(), rw.timeoutInSeconds))
 
 	if err != nil {
-		fmt.Println(encodeError(err))
 		return IterationResult{0, []StepResult{}, encodeError(err)}
 	} else {
 		json.Unmarshal([]byte(reply[1]), &result)

--- a/logs/config.go
+++ b/logs/config.go
@@ -1,0 +1,64 @@
+package logs
+
+import (
+	"os"
+	"strings"
+
+	"github.com/cloudfoundry-community/pat/config"
+	"github.com/cloudfoundry/gosteno"
+)
+
+var params = struct {
+	path  string
+	level string
+}{}
+
+func InitCommandLineFlags(flags config.Config) {
+	flags.StringVar(&params.path, "logging:file", "", "A file to log to, or empty to log to STDOUT")
+	flags.StringVar(&params.level, "logging:level", "INFO", "The level to log at, one of all, debug2, debug1, debug, info, warn, error, fatal, off")
+}
+
+var initialized bool
+
+func NewLogger(name string) *gosteno.Logger {
+	if !initialized {
+		initLogging()
+		initialized = true
+	}
+
+	return gosteno.NewLogger(name)
+}
+
+func initLogging() {
+	level, err := gosteno.GetLogLevel(strings.ToLower(params.level))
+	if err != nil {
+		panic(err)
+	}
+
+	sinks := []gosteno.Sink{}
+	if params.path != "" {
+		sinks = append(sinks, NewFileSink(params.path))
+	} else {
+		sinks = append(sinks, NewIOSink(os.Stdout))
+	}
+
+	c := &gosteno.Config{
+		Sinks:     sinks,
+		Level:     level,
+		EnableLOC: true,
+	}
+
+	InitGoSteno(c)
+}
+
+var InitGoSteno = func(c *gosteno.Config) {
+	gosteno.Init(c)
+}
+
+var NewFileSink = func(path string) gosteno.Sink {
+	return gosteno.NewFileSink(path)
+}
+
+var NewIOSink = func(file *os.File) gosteno.Sink {
+	return gosteno.NewIOSink(file)
+}

--- a/logs/config.go
+++ b/logs/config.go
@@ -30,6 +30,10 @@ func NewLogger(name string) *gosteno.Logger {
 }
 
 func initLogging() {
+	if params.level == "" {
+		params.level = "off"
+	}
+
 	level, err := gosteno.GetLogLevel(strings.ToLower(params.level))
 	if err != nil {
 		panic(err)

--- a/logs/logs_suite_test.go
+++ b/logs/logs_suite_test.go
@@ -1,0 +1,13 @@
+package logs
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestLogs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Logs Suite")
+}

--- a/logs/logs_test.go
+++ b/logs/logs_test.go
@@ -77,6 +77,18 @@ var _ = Describe("Logs", func() {
 		})
 	})
 
+	Context("When -logging:level is empty", func() {
+		BeforeEach(func() {
+			args = []string{"-logging:level", ""}
+		})
+
+		It("Turns logs off (useful for tests)", func() {
+			NewLogger("test").Debug("Debug")
+			NewLogger("test").Info("Info")
+			Ω(sink.records).Should(HaveLen(0))
+		})
+	})
+
 	Context("When -logging:level is specified", func() {
 		BeforeEach(func() {
 			args = []string{"-logging:level", "debug"}

--- a/logs/logs_test.go
+++ b/logs/logs_test.go
@@ -1,0 +1,133 @@
+package logs
+
+import (
+	"os"
+
+	"github.com/cloudfoundry-community/pat/config"
+	"github.com/cloudfoundry/gosteno"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Logs", func() {
+	var (
+		args       []string
+		sink       *notASink
+		flags      config.Config
+		calledInit int
+	)
+
+	BeforeEach(func() {
+		initialized = false
+		sink = &notASink{}
+		args = []string{}
+		flags = config.NewConfig()
+
+		NewIOSink = func(target *os.File) gosteno.Sink {
+			sink.target = target
+			sink.sinkType = "io"
+			return sink
+		}
+
+		NewFileSink = func(target string) gosteno.Sink {
+			sink.target = target
+			sink.sinkType = "file"
+			return sink
+		}
+
+		InitGoSteno = func(c *gosteno.Config) {
+			calledInit++
+			gosteno.Init(c)
+		}
+	})
+
+	JustBeforeEach(func() {
+		InitCommandLineFlags(flags)
+		flags.Parse(args)
+	})
+
+	It("Only calls gosteno.Init once", func() {
+		NewLogger("abc").Info("easy as 123")
+		NewLogger("so simple as").Info("abc, 123, you and me, baby")
+		Ω(calledInit).Should(Equal(1))
+	})
+
+	It("Uses a JSON codec", func() {
+		NewLogger("jenny.from.the.block")
+		Ω(sink.GetCodec()).Should(BeAssignableToTypeOf(&gosteno.JsonCodec{}))
+	})
+
+	Context("When -logging:file is not specified", func() {
+		It("logs to stdout", func() {
+			NewLogger("jenny.from.the.block").Info("on the 6")
+			Ω(sink.sinkType).Should(Equal("io"))
+			Ω(sink.target).Should(Equal(os.Stdout))
+		})
+	})
+
+	Context("When -logging:file is specified", func() {
+		BeforeEach(func() {
+			args = []string{"-logging:file", "/tmp/thelog"}
+		})
+
+		It("logs to the given file", func() {
+			NewLogger("innerversions")
+			Ω(sink.sinkType).Should(Equal("file"))
+			Ω(sink.target).Should(Equal("/tmp/thelog"))
+		})
+	})
+
+	Context("When -logging:level is specified", func() {
+		BeforeEach(func() {
+			args = []string{"-logging:level", "debug"}
+		})
+
+		It("Logs at the given level", func() {
+			NewLogger("test").Debug("Message")
+			Ω(sink.records).Should(ContainElement("Message"))
+		})
+
+		Context(".. with capitalization errors", func() {
+			BeforeEach(func() {
+				args = []string{"-logging:level", "DEBUG"}
+			})
+
+			It("Still Logs at the given level", func() {
+				NewLogger("test").Debug("Message")
+				Ω(sink.records).Should(ContainElement("Message"))
+			})
+		})
+
+		Context(".. but if the logging level is invalid", func() {
+			BeforeEach(func() {
+				args = []string{"-logging:level", "NotALoggingLevel"}
+			})
+
+			It("panicks", func() {
+				Ω(func() { NewLogger("test") }).Should(Panic())
+			})
+		})
+	})
+})
+
+type notASink struct {
+	codec    gosteno.Codec
+	records  []string
+	target   interface{}
+	sinkType string
+}
+
+func (s *notASink) AddRecord(record *gosteno.Record) {
+	s.records = append(s.records, record.Message)
+}
+
+func (s *notASink) Flush() {
+}
+
+func (s *notASink) SetCodec(c gosteno.Codec) {
+	s.codec = c
+}
+
+func (s *notASink) GetCodec() gosteno.Codec {
+	return s.codec
+}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cloudfoundry-community/pat/cmdline"
 	"github.com/cloudfoundry-community/pat/config"
+	"github.com/cloudfoundry-community/pat/logs"
 	"github.com/cloudfoundry-community/pat/server"
 )
 
@@ -14,13 +15,13 @@ func main() {
 	flags := config.ConfigAndFlags
 	flags.BoolVar(&useServer, "server", false, "true to run the HTTP server interface")
 
-	logs.InitCommandLingFlags(flags)
+	logs.InitCommandLineFlags(flags)
 	cmdline.InitCommandLineFlags(flags)
 	server.InitCommandLineFlags(flags)
 	flags.Parse(os.Args[1:])
 
 	if useServer == true {
-		fmt.Println("Starting in server mode")
+		logs.NewLogger("main").Info("Starting in server mode")
 		server.Serve()
 	} else {
 		err := cmdline.RunCommandLine()

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ func main() {
 	flags := config.ConfigAndFlags
 	flags.BoolVar(&useServer, "server", false, "true to run the HTTP server interface")
 
+	logs.InitCommandLingFlags(flags)
 	cmdline.InitCommandLineFlags(flags)
 	server.InitCommandLineFlags(flags)
 	flags.Parse(os.Args[1:])

--- a/redis/conn.go
+++ b/redis/conn.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"fmt"
 
+	"github.com/cloudfoundry-community/pat/logs"
 	"github.com/garyburd/redigo/redis"
 )
 
@@ -17,7 +18,7 @@ type conn struct {
 }
 
 func Connect(host string, port int, password string) (Conn, error) {
-	fmt.Printf("Dialling redis on %s:%d", host, port)
+	logs.NewLogger("redis.conn").Debugf("Dialling redis on %s:%d", host, port)
 	return test(&conn{redis.NewPool(func() (redis.Conn, error) { return connect(host, port, password) }, MAX_IDLE)}, nil)
 }
 
@@ -40,7 +41,7 @@ func test(conn *conn, err error) (Conn, error) {
 	}
 
 	if err != nil {
-		fmt.Println("Redis connection failed")
+		logs.NewLogger("redis.conn").Error("Redis connection failed")
 	}
 	return conn, err
 }

--- a/server/server.go
+++ b/server/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cloudfoundry-community/pat/config"
 	. "github.com/cloudfoundry-community/pat/experiment"
 	. "github.com/cloudfoundry-community/pat/laboratory"
+	"github.com/cloudfoundry-community/pat/logs"
 	"github.com/cloudfoundry-community/pat/store"
 	"github.com/gorilla/mux"
 )
@@ -77,7 +78,7 @@ func redirectBase(w http.ResponseWriter, r *http.Request) {
 func bind() {
 	port := params.port
 
-	fmt.Printf("Starting web ui on http://localhost:%s", port)
+	logs.NewLogger("server").Infof("Starting web ui on http://localhost:%s", port)
 	if err := ListenAndServe(":" + port); err != nil {
 		panic(err)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2,7 +2,6 @@ package server_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -224,7 +223,6 @@ func req(method string, url string) []byte {
 		Ω(err).NotTo(HaveOccurred())
 		return nil
 	} else {
-		fmt.Printf("Body: %s", body)
 		return body
 	}
 }

--- a/store/csv.go
+++ b/store/csv.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"encoding/csv"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cloudfoundry-community/pat/experiment"
+	"github.com/cloudfoundry-community/pat/logs"
 	"github.com/cloudfoundry-community/pat/workloads"
 )
 
@@ -49,16 +49,18 @@ func (file *csvFile) AddWorkloadStep(workload workloads.WorkloadStep) {
 }
 
 func (self *csvFile) Write(samples <-chan *experiment.Sample) {
+	var logger = logs.NewLogger("store.csv")
+
 	f, err := os.Create(self.outputPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			fmt.Println("Creating directory, ", filepath.Dir(self.outputPath))
+			logger.Infof("Creating directory, %s", filepath.Dir(self.outputPath))
 			os.MkdirAll(filepath.Dir(self.outputPath), 0755)
 			f, err = os.Create(self.outputPath)
 		}
 
 		if err != nil {
-			fmt.Println("Can't write CSV: ", err)
+			logger.Errorf("Can't write CSV: %v", err)
 		}
 	}
 	defer f.Close()

--- a/workloads/gcf_test.go
+++ b/workloads/gcf_test.go
@@ -16,7 +16,7 @@ var _ = Describe("GCF Workloads", func() {
 	var (
 		srcDir string
 		dstDir string
-	)	
+	)
 	BeforeEach(func() {
 		srcDir = path.Join(os.TempDir(), "src")
 		dstDir = path.Join(os.TempDir(), "dst")
@@ -40,7 +40,7 @@ var _ = Describe("GCF Workloads", func() {
 				Ω(info.IsDir()).Should(Equal(true))
 				Ω(subInfo.IsDir()).Should(Equal(true))
 			})
-			
+
 			It("Copies any files contained the source directory or subdirectories", func() {
 				os.MkdirAll(path.Join(srcDir, "subdir"), 0777)
 				file, _ := os.Create(path.Join(srcDir, "test.txt"))
@@ -49,12 +49,15 @@ var _ = Describe("GCF Workloads", func() {
 				subFile, _ := os.Create(path.Join(srcDir, "subdir", "subfile.txt"))
 				subFile.WriteString("foobar")
 				subFile.Close()
-				
+
 				CopyAndReplaceText(srcDir, dstDir, "", "")
 				dstFile, err := ioutil.ReadFile(path.Join(dstDir, "test.txt"))
 				dstSubfile, err2 := ioutil.ReadFile(path.Join(dstDir, "subdir", "subfile.txt"))
 
+<<<<<<< HEAD
 
+=======
+>>>>>>> Convert existing logs to gosteno
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(err2).ShouldNot(HaveOccurred())
 				Ω(string(dstFile)).Should(Equal("abc123"))
@@ -72,7 +75,7 @@ var _ = Describe("GCF Workloads", func() {
 				subFile.Close()
 
 				CopyAndReplaceText(srcDir, dstDir, "$RANDOM_TEXT", "qwerty")
-			
+
 				dstFile, err := ioutil.ReadFile(path.Join(dstDir, "test.txt"))
 				dstSubfile, err2 := ioutil.ReadFile(path.Join(dstDir, "subdir", "subfile.txt"))
 

--- a/workloads/gcf_test.go
+++ b/workloads/gcf_test.go
@@ -54,10 +54,6 @@ var _ = Describe("GCF Workloads", func() {
 				dstFile, err := ioutil.ReadFile(path.Join(dstDir, "test.txt"))
 				dstSubfile, err2 := ioutil.ReadFile(path.Join(dstDir, "subdir", "subfile.txt"))
 
-<<<<<<< HEAD
-
-=======
->>>>>>> Convert existing logs to gosteno
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(err2).ShouldNot(HaveOccurred())
 				Ω(string(dstFile)).Should(Equal("abc123"))


### PR DESCRIPTION
Convert all the non-UI fmt.Printlns to steno, because: steno! 

(also because it should make debugging with the animated console UI on much easier, because you can divert logs to a file now with -logging:file=foo.log)
