### PR TITLE
replace deprecated HaveOccured() with HaveOccurred

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -216,12 +216,12 @@ func req(method string, url string) []byte {
 	resp := httptest.NewRecorder()
 	req, err := http.NewRequest(method, url, nil)
 	if err != nil {
-		Ω(err).NotTo(HaveOccured())
+		Ω(err).NotTo(HaveOccurred())
 	}
 
 	http.DefaultServeMux.ServeHTTP(resp, req)
 	if body, err := ioutil.ReadAll(resp.Body); err != nil {
-		Ω(err).NotTo(HaveOccured())
+		Ω(err).NotTo(HaveOccurred())
 		return nil
 	} else {
 		fmt.Printf("Body: %s", body)

--- a/workloads/gcf_test.go
+++ b/workloads/gcf_test.go
@@ -35,8 +35,8 @@ var _ = Describe("GCF Workloads", func() {
 				info, err := os.Lstat(dstDir)
 				subInfo, err2 := os.Lstat(path.Join(dstDir, "subdir"))
 
-				Ω(err).ShouldNot(HaveOccured())
-				Ω(err2).ShouldNot(HaveOccured())
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(err2).ShouldNot(HaveOccurred())
 				Ω(info.IsDir()).Should(Equal(true))
 				Ω(subInfo.IsDir()).Should(Equal(true))
 			})
@@ -55,8 +55,8 @@ var _ = Describe("GCF Workloads", func() {
 				dstSubfile, err2 := ioutil.ReadFile(path.Join(dstDir, "subdir", "subfile.txt"))
 
 
-				Ω(err).ShouldNot(HaveOccured())
-				Ω(err2).ShouldNot(HaveOccured())
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(err2).ShouldNot(HaveOccurred())
 				Ω(string(dstFile)).Should(Equal("abc123"))
 				Ω(string(dstSubfile)).Should(Equal("foobar"))
 			})
@@ -76,8 +76,8 @@ var _ = Describe("GCF Workloads", func() {
 				dstFile, err := ioutil.ReadFile(path.Join(dstDir, "test.txt"))
 				dstSubfile, err2 := ioutil.ReadFile(path.Join(dstDir, "subdir", "subfile.txt"))
 
-				Ω(err).ShouldNot(HaveOccured())
-				Ω(err2).ShouldNot(HaveOccured())
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(err2).ShouldNot(HaveOccurred())
 				Ω(strings.Contains(string(dstFile), "qwerty")).Should(Equal(true))
 				Ω(strings.Contains(string(dstSubfile), "qwerty")).Should(Equal(false))
 			})

--- a/workloads/rest_test.go
+++ b/workloads/rest_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Rest Workloads", func() {
 		Describe("When the API hasn't been targetted yet", func() {
 			It("Will return an error", func() {
 				err := rest.Login(context)
-				Ω(err).To(HaveOccured())
+				Ω(err).To(HaveOccurred())
 			})
 		})
 	})


### PR DESCRIPTION
I accidentally installed the newest ginkgo and the tests failed because HaveOccured() is deprecated.

This change replaced all HaveOccured() with HaveOccurred()
