### PR TITLE
allow rest:push to be used in Web UI

### DIFF
--- a/benchmarker/benchmarker.go
+++ b/benchmarker/benchmarker.go
@@ -23,30 +23,30 @@ func Time(experiment func() error) (result time.Duration, err error) {
 	return t1.Sub(t0), err
 }
 
-func Counted(out chan<- int, fn func(int)) func(int) {
-	return func(workerIndex int) {
+func Counted(out chan<- int, fn func(map[string]interface{})) func(map[string]interface{}) {
+	return func(workloadCtx map[string]interface{}) {
 		out <- 1
-		fn(workerIndex)
+		fn(workloadCtx)
 		out <- -1
 	}
 }
 
-func TimedWithWorker(out chan<- IterationResult, worker Worker, experiment string) func(int) {
-	return func(workerIndex int) {
-		time := worker.Time(experiment, workerIndex)
+func TimedWithWorker(out chan<- IterationResult, worker Worker, experiment string) func(map[string]interface{}) {
+	return func(workloadCtx map[string]interface{}) {
+		time := worker.Time(experiment, workloadCtx)
 		out <- time
 	}
 }
 
-func Once(fn func(int)) <-chan func(int) {
+func Once(fn func(map[string]interface{})) <-chan func(map[string]interface{}) {
 	return Repeat(1, fn)
 }
 
-func RepeatEveryUntil(repeatInterval int, runTime int, fn func(int), quit <-chan bool) <-chan func(int) {
+func RepeatEveryUntil(repeatInterval int, runTime int, fn func(map[string]interface{}), quit <-chan bool) <-chan func(map[string]interface{}) {
 	if repeatInterval == 0 || runTime == 0 {
 		return Once(fn)
 	} else {
-		ch := make(chan func(int))
+		ch := make(chan func(map[string]interface{}))
 		var tickerQuit *time.Ticker
 		ticker := time.NewTicker(time.Duration(repeatInterval) * time.Second)
 		if runTime > 0 {
@@ -72,8 +72,8 @@ func RepeatEveryUntil(repeatInterval int, runTime int, fn func(int), quit <-chan
 	}
 }
 
-func Repeat(n int, fn func(int)) <-chan func(int) {
-	ch := make(chan func(int))
+func Repeat(n int, fn func(map[string]interface{})) <-chan func(map[string]interface{}) {
+	ch := make(chan func(map[string]interface{}))
 	go func() {
 		defer close(ch)
 		for i := 0; i < n; i++ {
@@ -83,22 +83,31 @@ func Repeat(n int, fn func(int)) <-chan func(int) {
 	return ch
 }
 
-func Execute(tasks <-chan func(int)) {
-	for task := range tasks {
-		task(1)
+func Execute(tasks <-chan func(map[string]interface{}), workloadCtx map[string]interface{}) {
+	for task := range tasks {		
+		task(workloadCtx)
 	}
 }
 
-func ExecuteConcurrently(workers int, tasks <-chan func(int)) {
+func ExecuteConcurrently(workers int, tasks <-chan func(map[string]interface{}), workloadCtx map[string]interface{}) {
 	var wg sync.WaitGroup
 	for i := 0; i < workers; i++ {
 		wg.Add(1)
-		go func(t <-chan func(int), n int) {
+		workloadCtx["workerIndex"] = i
+		go func(t <-chan func(map[string]interface{}), ctx map[string]interface{}) {
 			defer wg.Done()
 			for task := range t {
-				task(n)
+				task(ctx)
 			}
-		}(tasks, i)
+		}(tasks, clone(workloadCtx))
 	}
 	wg.Wait()
+}
+
+func clone(src map[string]interface{}) map[string]interface{} {
+	var clone = make(map[string]interface{})
+	for k, v := range src {
+    	clone[k] = v
+	}
+	return clone
 }

--- a/benchmarker/benchmarker_test.go
+++ b/benchmarker/benchmarker_test.go
@@ -1,7 +1,7 @@
 package benchmarker
 
 import (
-	. "github.com/cloudfoundry-community/pat/workloads"
+	. "github.com/cloudfoundry-incubator/pat/workloads"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"time"

--- a/benchmarker/benchmarker_test.go
+++ b/benchmarker/benchmarker_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Benchmarker", func() {
 			workloadCtx["cfUsername"] = ""
 		})
 
-		It("passes workloadCtx map to the test functions", func() {
+		It("passes workloadCtx map to the test functions", func() {			
 			var cfUsername = ""
 
 			workloadCtx["cfUsername"] = "user1,user2"
@@ -128,7 +128,7 @@ var _ = Describe("Benchmarker", func() {
 			workloadCtx["cfTarget"] = ""
 		})
 
-		It("passes workloadCtx map to the test functions", func() {			
+		It("passes workloadCtx map to the test functions", func() {		
  			var cfTarget = ""
 			workloadCtx["cfTarget"] = "http://localhost/"
  			var fn = func(ctx map[string]interface{}) { 

--- a/benchmarker/benchmarker_test.go
+++ b/benchmarker/benchmarker_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 var _ = Describe("Benchmarker", func() {
-	workloadCtx := context.WorkloadContext( context.NewWorkloadContent() )
+	workloadCtx := context.New()
 
 	Describe("#Time", func() {
 		It("times an arbitrary function", func() {

--- a/benchmarker/benchmarker_test.go
+++ b/benchmarker/benchmarker_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 var _ = Describe("Benchmarker", func() {
+	workloadCtx := make(map[string]interface{})
+
 	Describe("#Time", func() {
 		It("times an arbitrary function", func() {
 			time, _ := Time(func() error { time.Sleep(2 * time.Second); return nil })
@@ -16,7 +18,7 @@ var _ = Describe("Benchmarker", func() {
 	})
 
 	Describe("TimedWithWorker", func() {
-		It("sends the timing information retrieved from a worker to a channel", func() {
+		It("sends the timing information retrieved from a worker to a channel", func() {			
 			ch := make(chan IterationResult)
 			result := make(chan time.Duration)
 			go func(result chan time.Duration) {
@@ -26,7 +28,7 @@ var _ = Describe("Benchmarker", func() {
 				}
 			}(result)
 
-			TimedWithWorker(ch, &DummyWorker{}, "three")(0)
+			TimedWithWorker(ch, &DummyWorker{}, "three")(workloadCtx)
 			Ω((<-result).Seconds()).Should(BeNumerically("==", 3))
 		})
 	})
@@ -34,7 +36,7 @@ var _ = Describe("Benchmarker", func() {
 	Describe("Counted", func() {
 		It("Sends +1 when the function is called, and -1 when it ends", func() {
 			ch := make(chan int)
-			go Counted(ch, func(int) {})(0)
+			go Counted(ch, func(map[string]interface{}) {})(workloadCtx)
 			Ω(<-ch).Should(Equal(+1))
 			Ω(<-ch).Should(Equal(-1))
 		})
@@ -43,7 +45,7 @@ var _ = Describe("Benchmarker", func() {
 	Describe("Once", func() {
 		It("repeats a function once", func() {
 			called := 0
-			Execute(Once(func(int) { called = called + 1 }))
+			Execute(Once(func(map[string]interface{}) { called = called + 1 }), workloadCtx)
 			Ω(called).Should(Equal(1))
 		})
 	})
@@ -51,7 +53,7 @@ var _ = Describe("Benchmarker", func() {
 	Describe("Repeat", func() {
 		It("repeats a function N times", func() {
 			called := 0
-			Execute(Repeat(3, func(int) { called = called + 1 }))
+			Execute(Repeat(3, func(map[string]interface{}) { called = called + 1 }), workloadCtx)
 			Ω(called).Should(Equal(3))
 		})
 	})
@@ -61,7 +63,7 @@ var _ = Describe("Benchmarker", func() {
 			start := time.Now()
 			var end time.Time
 			n := 2
-			Execute(RepeatEveryUntil(n, 3, func(int) { end = time.Now() }, nil))
+			Execute(RepeatEveryUntil(n, 3, func(map[string]interface{}) { end = time.Now() }, nil), workloadCtx)
 			elapsed := end.Sub(start)
 			elapsed = (elapsed / time.Second)
 			Ω(int(elapsed)).Should(Equal(n))
@@ -71,7 +73,7 @@ var _ = Describe("Benchmarker", func() {
 			var total int = 0
 			n := 2
 			s := 11
-			Execute(RepeatEveryUntil(n, s, func(int) { total += 1 }, nil))
+			Execute(RepeatEveryUntil(n, s, func(map[string]interface{}) { total += 1 }, nil), workloadCtx)
 			Ω(total).Should(Equal((s / n) + 1))
 		})
 
@@ -82,7 +84,7 @@ var _ = Describe("Benchmarker", func() {
 			s := 11
 			stop := 5
 			time.AfterFunc(time.Duration(stop)*time.Second, func() { quit <- true })
-			Execute(RepeatEveryUntil(n, s, func(int) { total += 1 }, quit))
+			Execute(RepeatEveryUntil(n, s, func(map[string]interface{}) { total += 1 }, quit), workloadCtx)
 			Ω(total).Should(Equal((stop / n) + 1))
 		})
 
@@ -90,14 +92,51 @@ var _ = Describe("Benchmarker", func() {
 			var total int = 0
 			n := 0
 			s := 1
-			Execute(RepeatEveryUntil(n, s, func(int) { total += 1 }, nil))
+			Execute(RepeatEveryUntil(n, s, func(map[string]interface{}) { total += 1 }, nil), workloadCtx)
 			Ω(total).Should(Equal(1))
 
 			total = 0
 			n = 3
 			s = 0
-			Execute(RepeatEveryUntil(n, s, func(int) { total += 1 }, nil))
+			Execute(RepeatEveryUntil(n, s, func(map[string]interface{}) { total += 1 }, nil), workloadCtx)
 			Ω(total).Should(Equal(1))
+		})
+	})
+
+	Describe("Execute", func() {
+		AfterEach(func() {
+			workloadCtx["cfUsername"] = ""
+		})
+
+		It("passes workloadCtx map to the test functions", func() {
+			var cfUsername = ""
+
+			workloadCtx["cfUsername"] = "user1,user2"
+
+ 			var fn = func(ctx map[string]interface{}) { 
+	 			cfUsername = ctx["cfUsername"].(string)
+ 			}
+
+ 			Execute(RepeatEveryUntil(0, 0, func(map[string]interface{}) { ExecuteConcurrently(1, Repeat(1, fn), workloadCtx) }, nil), workloadCtx)
+			 			
+ 			Ω(cfUsername).Should(Equal("user1,user2"))
+		})
+	})
+
+	Describe("ExecuteConcurrently", func() {
+		AfterEach(func() {
+			workloadCtx["cfTarget"] = ""
+		})
+
+		It("passes workloadCtx map to the test functions", func() {			
+ 			var cfTarget = ""
+			workloadCtx["cfTarget"] = "http://localhost/"
+ 			var fn = func(ctx map[string]interface{}) { 
+	 			cfTarget = ctx["cfTarget"].(string)
+ 			}
+			
+ 			ExecuteConcurrently(1, Repeat(1, fn), workloadCtx)
+ 			Ω(cfTarget).Should(Equal("http://localhost/"))
 		})
 	})
 
@@ -105,7 +144,7 @@ var _ = Describe("Benchmarker", func() {
 		Context("with 1 worker", func() {
 			It("Runs in series", func() {
 				result, _ := Time(func() error {
-					ExecuteConcurrently(1, Repeat(3, func(int) { time.Sleep(1 * time.Second) }))
+					ExecuteConcurrently(1, Repeat(3, func(map[string]interface{}) { time.Sleep(1 * time.Second) }), workloadCtx)
 					return nil
 				})
 				Ω(result.Seconds()).Should(BeNumerically("~", 3, 1))
@@ -115,18 +154,19 @@ var _ = Describe("Benchmarker", func() {
 		Context("With 3 workers", func() {
 			It("Runs in parallel", func() {
 				result, _ := Time(func() error {
-					ExecuteConcurrently(3, Repeat(3, func(int) { time.Sleep(2 * time.Second) }))
+					ExecuteConcurrently(3, Repeat(3, func(map[string]interface{}) { time.Sleep(2 * time.Second) }), workloadCtx)
 					return nil
 				})
 				Ω(result.Seconds()).Should(BeNumerically("~", 2, 1))
 			})
 		})
 	})
+
 })
 
 type DummyWorker struct{}
 
-func (*DummyWorker) Time(experiment string, index int) IterationResult {
+func (*DummyWorker) Time(experiment string, workloadCtx map[string]interface{}) IterationResult {
 	var result IterationResult
 	if experiment == "three" {
 		result.Duration = 3 * time.Second

--- a/benchmarker/config.go
+++ b/benchmarker/config.go
@@ -3,9 +3,9 @@ package benchmarker
 import (
 	"io"
 
-	"github.com/cloudfoundry-community/pat/config"
-	"github.com/cloudfoundry-community/pat/redis"
-	"github.com/cloudfoundry-community/pat/workloads"
+	"github.com/cloudfoundry-incubator/pat/config"
+	"github.com/cloudfoundry-incubator/pat/redis"
+	"github.com/cloudfoundry-incubator/pat/workloads"
 )
 
 var RedisContextMapStr = []string{"cfTarget", "cfUsername", "cfPassword"}

--- a/benchmarker/config.go
+++ b/benchmarker/config.go
@@ -8,6 +8,8 @@ import (
 	"github.com/cloudfoundry-community/pat/workloads"
 )
 
+var RedisContextMapStr = []string{"cfTarget", "cfUsername", "cfPassword"}
+
 var params = struct {
 	startMasterAndSlave bool
 }{}

--- a/benchmarker/config_test.go
+++ b/benchmarker/config_test.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"io"
 
-	"github.com/cloudfoundry-community/pat/config"
-	"github.com/cloudfoundry-community/pat/redis"
-	"github.com/cloudfoundry-community/pat/workloads"
+	"github.com/cloudfoundry-incubator/pat/config"
+	"github.com/cloudfoundry-incubator/pat/redis"
+	"github.com/cloudfoundry-incubator/pat/workloads"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/benchmarker/local.go
+++ b/benchmarker/local.go
@@ -3,8 +3,8 @@ package benchmarker
 import (
 	"strings"
 	"time"
-	"fmt"
 
+	"github.com/cloudfoundry-incubator/pat/context"
 	"github.com/cloudfoundry-incubator/pat/workloads"
 )
 
@@ -16,13 +16,11 @@ func NewLocalWorker() *LocalWorker {
 	return &LocalWorker{defaultWorker{make(map[string]workloads.WorkloadStep)}}
 }
 
-func (self *LocalWorker) Time(experiment string, workloadCtx map[string]interface{}) (result IterationResult) {		
-	fmt.Println("====== go func() 1a" + experiment)
+func (self *LocalWorker) Time(experiment string, workloadCtx context.WorkloadContext) (result IterationResult) {
 	experiments := strings.Split(experiment, ",")
-	fmt.Println("====== go func() 1b " )
 	var start = time.Now()
 	for _, e := range experiments {		
-		stepTime, err := Time(func() error { return self.Experiments[e].Fn(workloadCtx) })		
+		stepTime, err := Time(func() error { return self.Experiments[e].Fn(workloadCtx) })			
 		result.Steps = append(result.Steps, StepResult{e, stepTime})		
 		if err != nil {
 			result.Error = encodeError(err)

--- a/benchmarker/local.go
+++ b/benchmarker/local.go
@@ -3,6 +3,7 @@ package benchmarker
 import (
 	"strings"
 	"time"
+	"fmt"
 
 	"github.com/cloudfoundry-incubator/pat/workloads"
 )
@@ -16,13 +17,13 @@ func NewLocalWorker() *LocalWorker {
 }
 
 func (self *LocalWorker) Time(experiment string, workloadCtx map[string]interface{}) (result IterationResult) {		
-	
+	fmt.Println("====== go func() 1a" + experiment)
 	experiments := strings.Split(experiment, ",")
-
+	fmt.Println("====== go func() 1b " )
 	var start = time.Now()
 	for _, e := range experiments {		
 		stepTime, err := Time(func() error { return self.Experiments[e].Fn(workloadCtx) })		
-		result.Steps = append(result.Steps, StepResult{e, stepTime})
+		result.Steps = append(result.Steps, StepResult{e, stepTime})		
 		if err != nil {
 			result.Error = encodeError(err)
 			break

--- a/benchmarker/local.go
+++ b/benchmarker/local.go
@@ -16,10 +16,12 @@ func NewLocalWorker() *LocalWorker {
 }
 
 func (self *LocalWorker) Time(experiment string, workloadCtx map[string]interface{}) (result IterationResult) {		
+	
 	experiments := strings.Split(experiment, ",")
+
 	var start = time.Now()
-	for _, e := range experiments {
-		stepTime, err := Time(func() error { return self.Experiments[e].Fn(workloadCtx) })
+	for _, e := range experiments {		
+		stepTime, err := Time(func() error { return self.Experiments[e].Fn(workloadCtx) })		
 		result.Steps = append(result.Steps, StepResult{e, stepTime})
 		if err != nil {
 			result.Error = encodeError(err)

--- a/benchmarker/local.go
+++ b/benchmarker/local.go
@@ -15,13 +15,11 @@ func NewLocalWorker() *LocalWorker {
 	return &LocalWorker{defaultWorker{make(map[string]workloads.WorkloadStep)}}
 }
 
-func (self *LocalWorker) Time(experiment string, workerIndex int) (result IterationResult) {	
+func (self *LocalWorker) Time(experiment string, workloadCtx map[string]interface{}) (result IterationResult) {		
 	experiments := strings.Split(experiment, ",")
 	var start = time.Now()
-	context := make(map[string]interface{})
-	context["workerIndex"] = workerIndex
 	for _, e := range experiments {
-		stepTime, err := Time(func() error { return self.Experiments[e].Fn(context) })
+		stepTime, err := Time(func() error { return self.Experiments[e].Fn(workloadCtx) })
 		result.Steps = append(result.Steps, StepResult{e, stepTime})
 		if err != nil {
 			result.Error = encodeError(err)

--- a/benchmarker/local.go
+++ b/benchmarker/local.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cloudfoundry-community/pat/workloads"
+	"github.com/cloudfoundry-incubator/pat/workloads"
 )
 
 type LocalWorker struct {

--- a/benchmarker/local_test.go
+++ b/benchmarker/local_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var _ = Describe("LocalWorker", func() {
-	workloadCtx := context.WorkloadContext( context.NewWorkloadContent() )
+	workloadCtx := context.New()
 
 	Describe("When a single experiment is provided", func() {
 		It("Times a function by name", func() {

--- a/benchmarker/local_test.go
+++ b/benchmarker/local_test.go
@@ -9,25 +9,27 @@ import (
 )
 
 var _ = Describe("LocalWorker", func() {
+	workloadCtx := make(map[string]interface{})
+
 	Describe("When a single experiment is provided", func() {
 		It("Times a function by name", func() {
 			worker := NewLocalWorker()
 			worker.AddWorkloadStep(Step("foo", func() error { time.Sleep(1 * time.Second); return nil }, ""))
-			result := worker.Time("foo", 0)
+			result := worker.Time("foo", workloadCtx)
 			Ω(result.Duration.Seconds()).Should(BeNumerically("~", 1, 0.1))
 		})
 
 		It("Sets the function command name in the response struct", func() {
 			worker := NewLocalWorker()
 			worker.AddWorkloadStep(Step("foo", func() error { time.Sleep(1 * time.Second); return nil }, ""))
-			result := worker.Time("foo", 0)
+			result := worker.Time("foo", workloadCtx)
 			Ω(result.Steps[0].Command).Should(Equal("foo"))
 		})
 
 		It("Returns any errors", func() {
 			worker := NewLocalWorker()
 			worker.AddWorkloadStep(Step("foo", func() error { return errors.New("Foo") }, ""))
-			result := worker.Time("foo", 0)
+			result := worker.Time("foo", workloadCtx)
 			Ω(result.Error).Should(HaveOccurred())
 		})
 
@@ -36,7 +38,7 @@ var _ = Describe("LocalWorker", func() {
 			worker := NewLocalWorker()
 			worker.AddWorkloadStep(StepWithContext("foo", func(ctx map[string]interface{}) error { context = ctx; ctx["a"] = 1; return nil }, ""))
 			worker.AddWorkloadStep(StepWithContext("bar", func(ctx map[string]interface{}) error { ctx["a"] = ctx["a"].(int) + 2; return nil }, ""))
-			worker.Time("foo", 0)
+			worker.Time("foo", workloadCtx)
 			Ω(context).Should(HaveKey("a"))
 		})
 	})
@@ -49,7 +51,7 @@ var _ = Describe("LocalWorker", func() {
 			worker = NewLocalWorker()
 			worker.AddWorkloadStep(Step("foo", func() error { time.Sleep(1 * time.Second); return nil }, ""))
 			worker.AddWorkloadStep(Step("bar", func() error { time.Sleep(1 * time.Second); return nil }, ""))
-			result = worker.Time("foo,bar", 0)
+			result = worker.Time("foo,bar", workloadCtx)
 		})
 
 		It("Reports the total time", func() {
@@ -78,7 +80,7 @@ var _ = Describe("LocalWorker", func() {
 			worker.AddWorkloadStep(Step("foo", func() error { time.Sleep(1 * time.Second); return nil }, ""))
 			worker.AddWorkloadStep(Step("bar", func() error { time.Sleep(1 * time.Second); return nil }, ""))
 			worker.AddWorkloadStep(Step("errors", func() error { return errors.New("fishfinger system overflow") }, ""))
-			result = worker.Time("foo,errors,bar", 0)
+			result = worker.Time("foo,errors,bar", workloadCtx)
 		})
 
 		It("Records the error", func() {
@@ -95,4 +97,5 @@ var _ = Describe("LocalWorker", func() {
 			Ω(result.Duration.Seconds()).Should(BeNumerically("~", 1, 0.1))
 		})
 	})
+
 })

--- a/benchmarker/local_test.go
+++ b/benchmarker/local_test.go
@@ -2,6 +2,8 @@ package benchmarker
 
 import (
 	"errors"
+
+	"github.com/cloudfoundry-incubator/pat/context"
 	. "github.com/cloudfoundry-incubator/pat/workloads"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -9,7 +11,7 @@ import (
 )
 
 var _ = Describe("LocalWorker", func() {
-	workloadCtx := make(map[string]interface{})
+	workloadCtx := context.WorkloadContext( context.NewWorkloadContent() )
 
 	Describe("When a single experiment is provided", func() {
 		It("Times a function by name", func() {
@@ -34,12 +36,12 @@ var _ = Describe("LocalWorker", func() {
 		})
 
 		It("Passes context to each step", func() {
-			var context map[string]interface{}
+			var workloadContent context.WorkloadContext
 			worker := NewLocalWorker()
-			worker.AddWorkloadStep(StepWithContext("foo", func(ctx map[string]interface{}) error { context = ctx; ctx["a"] = 1; return nil }, ""))
-			worker.AddWorkloadStep(StepWithContext("bar", func(ctx map[string]interface{}) error { ctx["a"] = ctx["a"].(int) + 2; return nil }, ""))
+			worker.AddWorkloadStep(StepWithContext("foo", func(ctx context.WorkloadContext) error { workloadContent = ctx; ctx.PutInt("a", 1); return nil }, ""))
+			worker.AddWorkloadStep(StepWithContext("bar", func(ctx context.WorkloadContext) error { ctx.PutInt("a", ctx.GetInt("a") + 2); return nil }, ""))
 			worker.Time("foo", workloadCtx)
-			Ω(context).Should(HaveKey("a"))
+			Ω(workloadContent.CheckExists("a")).Should(Equal(true))
 		})
 	})
 

--- a/benchmarker/local_test.go
+++ b/benchmarker/local_test.go
@@ -2,7 +2,7 @@ package benchmarker
 
 import (
 	"errors"
-	. "github.com/cloudfoundry-community/pat/workloads"
+	. "github.com/cloudfoundry-incubator/pat/workloads"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"time"

--- a/benchmarker/redis.go
+++ b/benchmarker/redis.go
@@ -5,10 +5,11 @@ import (
 	"strings"
 	"strconv"
 	"net/url"
+	"reflect"
 	
-	"github.com/cloudfoundry-community/pat/logs"
-	"github.com/cloudfoundry-community/pat/redis"
-	"github.com/cloudfoundry-community/pat/workloads"
+	"github.com/cloudfoundry-incubator/pat/logs"
+	"github.com/cloudfoundry-incubator/pat/redis"
+	"github.com/cloudfoundry-incubator/pat/workloads"
 	"github.com/nu7hatch/gouuid"
 )
 

--- a/benchmarker/redis_test.go
+++ b/benchmarker/redis_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"time"
+	"fmt"
 
 	"github.com/cloudfoundry-incubator/pat/redis"
 	"github.com/cloudfoundry-incubator/pat/workloads"
@@ -21,6 +22,7 @@ var _ = Describe("RedisWorker", func() {
 	)
 
 	BeforeEach(func() {
+		fmt.Println("in redis test before each")
 		StartRedis("../redis/redis.conf")
 		var err error
 		conn, err = redis.Connect("", 63798, "p4ssw0rd")
@@ -68,7 +70,7 @@ var _ = Describe("RedisWorker", func() {
 				context = make(map[string]interface{})
 				delegate.AddWorkloadStep(workloads.StepWithContext("fooWithContext", func(ctx map[string]interface{}) error { context = ctx; ctx["a"] = 1; return nil }, ""))
 				delegate.AddWorkloadStep(workloads.StepWithContext("barWithContext", func(ctx map[string]interface{}) error { ctx["a"] = ctx["a"].(int) + 2; return nil }, ""))
-				delegate.AddWorkloadStep(workloads.StepWithContext("recordWorkerIndex", func(ctx map[string]interface{}) error { wasCalledWithWorkerIndex = ctx["workerIndex"].(int); return nil }, ""))
+				delegate.AddWorkloadStep(workloads.StepWithContext("recordWorkerIndex", func(ctx map[string]interface{}) error { fmt.Println("in recordWorkerIndex()"); wasCalledWithWorkerIndex = (int)(ctx["workerIndex"].(float64)); return nil }, ""))
 				delegate.AddWorkloadStep(workloads.StepWithContext("recordWorkerUsername", func(ctx map[string]interface{}) error { wasCalledWithWorkerUsername = ctx["cfUsername"].(string); return nil }, ""))
 				delegate.AddWorkloadStep(workloads.StepWithContext("recordWorkerInfo", func(ctx map[string]interface{}) error { wasCalledWithRandomKey = ctx["RandomKey"].(string); wasCalledWithWorkerUsername = ctx["cfUsername"].(string); return nil }, ""))
 				delegate.AddWorkloadStep(workloads.StepWithContext("recordWorkerInt", func(ctx map[string]interface{}) error { wasCalledWithIntTypeKey = ctx["intTypeKey"].(int); return nil }, ""))
@@ -85,10 +87,12 @@ var _ = Describe("RedisWorker", func() {
 			})
 
 			It("passes workerIndex to delegate.Time()", func() {
+				fmt.Println("in test 1")
 				worker := NewRedisWorkerWithTimeout(conn, 1)
-				workloadCtx["workerIndex"] = 72
+				workloadCtx["workerIndex"] = int(72)
 				worker.Time("recordWorkerIndex", workloadCtx);
-				Ω(wasCalledWithWorkerIndex).Should(Equal(72))								
+				Ω(wasCalledWithWorkerIndex).Should(Equal(72))
+				fmt.Println("in test 1 done **")
 			})
 
 			It("Times a function by name", func() {				

--- a/benchmarker/redis_test.go
+++ b/benchmarker/redis_test.go
@@ -8,8 +8,8 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/cloudfoundry-community/pat/redis"
-	"github.com/cloudfoundry-community/pat/workloads"
+	"github.com/cloudfoundry-incubator/pat/redis"
+	"github.com/cloudfoundry-incubator/pat/workloads"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/benchmarker/redis_test.go
+++ b/benchmarker/redis_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"time"
-
+"fmt"
 	"github.com/cloudfoundry-incubator/pat/context"
 	"github.com/cloudfoundry-incubator/pat/redis"
 	"github.com/cloudfoundry-incubator/pat/workloads"
@@ -18,10 +18,11 @@ import (
 var _ = Describe("RedisWorker", func() {
 	var (
 		conn redis.Conn		
-		workloadCtx = context.WorkloadContext(context.NewWorkloadContent())
+		workloadCtx = context.New()
 	)
 
 	BeforeEach(func() {	
+		fmt.Println("beforeeach redis test")
 		StartRedis("../redis/redis.conf")
 		var err error
 		conn, err = redis.Connect("", 63798, "p4ssw0rd")
@@ -66,7 +67,7 @@ var _ = Describe("RedisWorker", func() {
 				delegate.AddWorkloadStep(workloads.Step("foo", func() error { time.Sleep(1 * time.Second); return nil }, ""))
 				delegate.AddWorkloadStep(workloads.Step("bar", func() error { time.Sleep(2 * time.Second); return nil }, ""))
 
-				localContext = context.WorkloadContext(context.NewWorkloadContent())
+				localContext = context.New()
 				delegate.AddWorkloadStep(workloads.StepWithContext("fooWithContext", func(ctx context.WorkloadContext) error { localContext = ctx; ctx.PutInt("a", 1); return nil }, ""))
 				delegate.AddWorkloadStep(workloads.StepWithContext("barWithContext", func(ctx context.WorkloadContext) error { ctx.PutInt("a", ctx.GetInt("a") + 2); return nil }, ""))
 				delegate.AddWorkloadStep(workloads.StepWithContext("recordWorkerIndex", func(ctx context.WorkloadContext) error { wasCalledWithWorkerIndex = ctx.GetInt("workerIndex"); return nil }, ""))
@@ -78,7 +79,7 @@ var _ = Describe("RedisWorker", func() {
 
 
 				slave = StartSlave(conn, delegate)
-				workloadCtx = context.WorkloadContext(context.NewWorkloadContent())
+				workloadCtx = context.New()
 				workloadCtx.PutInt("workerIndex" ,0)
 
 			})
@@ -88,10 +89,15 @@ var _ = Describe("RedisWorker", func() {
 				Ω(err).ShouldNot(HaveOccurred())
 			})
 
-			It("passes workerIndex to delegate.Time()", func() {	
+			It("passes workerIndex to delegate.Time()", func() {
+				fmt.Println("Workloadindex")
 				worker := NewRedisWorkerWithTimeout(conn, 1)
+				fmt.Println("Workloadindex 1")
 				workloadCtx.PutInt("workerIndex", 72)
+				fmt.Println("Workloadindex 2")
 				worker.Time("recordWorkerIndex", workloadCtx);
+				fmt.Println("Workloadindex 3")
+				fmt.Println("Workloadindex done")
 				Ω(wasCalledWithWorkerIndex).Should(Equal(72))
 			})
 
@@ -149,7 +155,8 @@ var _ = Describe("RedisWorker", func() {
 			Describe("Workload context map sending over Redis", func() {
 
 				AfterEach(func() {
-					workloadCtx = context.NewWorkloadContent()
+					//workloadCtx = context.NewWorkloadContent()
+					workloadCtx = context.New()
 				})
 
 				Describe("Contents in the context map", func() {

--- a/benchmarker/redis_test.go
+++ b/benchmarker/redis_test.go
@@ -146,7 +146,7 @@ var _ = Describe("RedisWorker", func() {
 
 			Describe("Workload context map sending over Redis", func() {
 
-				const spaceEscapeStr = "<%>"
+				const spaceEscapeStr = "%20"
 
 				AfterEach(func() {
 						workloadCtx["cfTarget"] = ""
@@ -162,14 +162,7 @@ var _ = Describe("RedisWorker", func() {
 						_ = worker.Time("recordWorkerInfo", workloadCtx)
 						Ω(wasCalledWithWorkerUsername).Should(Equal("user1"))
 						Ω(wasCalledWithNonListed).Should(Equal(""))
-					})
-
-					It("could contain the predefined escape character in the string and will not conflict", func() {
-						worker := NewRedisWorker(conn)
-						workloadCtx["cfUsername"] = "user1" + spaceEscapeStr + ", user2"
-						_ = worker.Time("recordWorkerUsername", workloadCtx)
-						Ω(wasCalledWithWorkerUsername).Should(Equal("user1" + spaceEscapeStr + ", user2"))
-					})
+					})					
 				})
 				
 				Describe("When content string contain spaces", func() {

--- a/benchmarker/worker.go
+++ b/benchmarker/worker.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/cloudfoundry-community/pat/workloads"
+	"github.com/cloudfoundry-incubator/pat/workloads"
 )
 
 type Worker interface {

--- a/benchmarker/worker.go
+++ b/benchmarker/worker.go
@@ -4,11 +4,12 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/cloudfoundry-incubator/pat/context"
 	"github.com/cloudfoundry-incubator/pat/workloads"
 )
 
 type Worker interface {
-	Time(experiment string, workloadCtx map[string]interface{}) IterationResult
+	Time(experiment string, workloadCtx context.WorkloadContext) IterationResult
 	AddWorkloadStep(workloads workloads.WorkloadStep)
 	Visit(fn func(workloads.WorkloadStep))
 	Validate(name string) (result bool, err error)

--- a/benchmarker/worker.go
+++ b/benchmarker/worker.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Worker interface {
-	Time(experiment string, workerIndex int) IterationResult
+	Time(experiment string, workloadCtx map[string]interface{}) IterationResult
 	AddWorkloadStep(workloads workloads.WorkloadStep)
 	Visit(fn func(workloads.WorkloadStep))
 	Validate(name string) (result bool, err error)

--- a/benchmarker/worker_test.go
+++ b/benchmarker/worker_test.go
@@ -1,7 +1,7 @@
 package benchmarker
 
 import (
-	. "github.com/cloudfoundry-community/pat/workloads"
+	. "github.com/cloudfoundry-incubator/pat/workloads"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"time"

--- a/benchmarker/worker_test.go
+++ b/benchmarker/worker_test.go
@@ -1,10 +1,10 @@
 package benchmarker
 
 import (
-	"time"
 	. "github.com/cloudfoundry-community/pat/workloads"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"time"
 )
 
 var _ = Describe("LocalWorker", func() {

--- a/cmdline/cmdline.go
+++ b/cmdline/cmdline.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/cloudfoundry-incubator/pat/context"
 	"github.com/cloudfoundry-incubator/pat/benchmarker"
 	"github.com/cloudfoundry-incubator/pat/config"
 	. "github.com/cloudfoundry-incubator/pat/experiment"
@@ -52,7 +53,7 @@ func RunCommandLine() error {
 					})
 				}
 
-				workloadContext := make(map[string]interface{})				
+				workloadContext := context.WorkloadContext( context.NewWorkloadContent() )
 
 				lab.RunWithHandlers(
 					NewRunnableExperiment(

--- a/cmdline/cmdline.go
+++ b/cmdline/cmdline.go
@@ -5,12 +5,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/cloudfoundry-community/pat/benchmarker"
-	"github.com/cloudfoundry-community/pat/config"
-	. "github.com/cloudfoundry-community/pat/experiment"
-	. "github.com/cloudfoundry-community/pat/laboratory"
-	"github.com/cloudfoundry-community/pat/store"
-	"github.com/cloudfoundry-community/pat/workloads"
+	"github.com/cloudfoundry-incubator/pat/benchmarker"
+	"github.com/cloudfoundry-incubator/pat/config"
+	. "github.com/cloudfoundry-incubator/pat/experiment"
+	. "github.com/cloudfoundry-incubator/pat/laboratory"
+	"github.com/cloudfoundry-incubator/pat/store"
+	"github.com/cloudfoundry-incubator/pat/workloads"
 )
 
 var params = struct {

--- a/cmdline/cmdline.go
+++ b/cmdline/cmdline.go
@@ -53,7 +53,8 @@ func RunCommandLine() error {
 					})
 				}
 
-				workloadContext := context.WorkloadContext( context.NewWorkloadContent() )
+				//workloadContext := context.WorkloadContext( context.NewWorkloadContent() )
+				workloadContext := context.New()
 
 				lab.RunWithHandlers(
 					NewRunnableExperiment(

--- a/cmdline/cmdline_test.go
+++ b/cmdline/cmdline_test.go
@@ -3,6 +3,7 @@ package cmdline_test
 import (
 	"fmt"
 
+	"github.com/cloudfoundry-incubator/pat/context"
 	"github.com/cloudfoundry-incubator/pat/benchmarker"
 	. "github.com/cloudfoundry-incubator/pat/cmdline"
 	"github.com/cloudfoundry-incubator/pat/config"
@@ -173,11 +174,11 @@ func (d *dummyLab) GetData(guid string) ([]*experiment.Sample, error) {
 	return nil, nil
 }
 
-func (d *dummyLab) Run(runnable laboratory.Runnable, workloadCtx map[string]interface{}) (string, error) {
+func (d *dummyLab) Run(runnable laboratory.Runnable, workloadCtx context.WorkloadContext) (string, error) {
 	return "", nil
 }
 
-func (d *dummyLab) RunWithHandlers(runnable laboratory.Runnable, handlers []func(<-chan *experiment.Sample), workloadCtx map[string]interface{}) (string, error) {
+func (d *dummyLab) RunWithHandlers(runnable laboratory.Runnable, handlers []func(<-chan *experiment.Sample), workloadCtx context.WorkloadContext) (string, error) {
 	d.lastRunWith = runnable.(*experiment.RunnableExperiment)
 	return "", nil
 }

--- a/cmdline/cmdline_test.go
+++ b/cmdline/cmdline_test.go
@@ -3,12 +3,12 @@ package cmdline_test
 import (
 	"fmt"
 
-	"github.com/cloudfoundry-community/pat/benchmarker"
-	. "github.com/cloudfoundry-community/pat/cmdline"
-	"github.com/cloudfoundry-community/pat/config"
-	"github.com/cloudfoundry-community/pat/experiment"
-	"github.com/cloudfoundry-community/pat/laboratory"
-	"github.com/cloudfoundry-community/pat/workloads"
+	"github.com/cloudfoundry-incubator/pat/benchmarker"
+	. "github.com/cloudfoundry-incubator/pat/cmdline"
+	"github.com/cloudfoundry-incubator/pat/config"
+	"github.com/cloudfoundry-incubator/pat/experiment"
+	"github.com/cloudfoundry-incubator/pat/laboratory"
+	"github.com/cloudfoundry-incubator/pat/workloads"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/cmdline/cmdline_test.go
+++ b/cmdline/cmdline_test.go
@@ -40,7 +40,6 @@ var _ = Describe("Cmdline", func() {
 		flags = config.NewConfig()
 		InitCommandLineFlags(flags)
 		flags.Parse(args)
-
 		BlockExit = func() {}
 		RunCommandLine()
 	})
@@ -66,12 +65,24 @@ var _ = Describe("Cmdline", func() {
 	})
 
 	Describe("When -workload is supplied", func() {
-		BeforeEach(func() {
-			args = []string{"-workload", "login,push"}
+		Describe("When -workload contains no white spaces", func() {
+			BeforeEach(func() {
+				args = []string{"-workload", "login,push"}
+			})
+
+			It("configures the experiment with the parameter", func() {
+				Ω(lab).Should(HaveBeenRunWith("workload", "login,push"))
+			})
 		})
 
-		It("configures the experiment with the parameter", func() {
-			Ω(lab).Should(HaveBeenRunWith("workload", "login,push"))
+		Describe("When -workload contains white spaces", func() {
+			BeforeEach(func() {
+				args = []string{"-workload", "  login ,  push , gcf:push"}
+			})
+
+			It("removes white spaces in the parameter", func() {
+				Ω(lab).Should(HaveBeenRunWith("workload", "login,push,gcf:push"))
+			})
 		})
 	})
 
@@ -162,11 +173,11 @@ func (d *dummyLab) GetData(guid string) ([]*experiment.Sample, error) {
 	return nil, nil
 }
 
-func (d *dummyLab) Run(runnable laboratory.Runnable) (string, error) {
+func (d *dummyLab) Run(runnable laboratory.Runnable, workloadCtx map[string]interface{}) (string, error) {
 	return "", nil
 }
 
-func (d *dummyLab) RunWithHandlers(runnable laboratory.Runnable, handlers []func(<-chan *experiment.Sample)) (string, error) {
+func (d *dummyLab) RunWithHandlers(runnable laboratory.Runnable, handlers []func(<-chan *experiment.Sample), workloadCtx map[string]interface{}) (string, error) {
 	d.lastRunWith = runnable.(*experiment.RunnableExperiment)
 	return "", nil
 }

--- a/cmdline/display.go
+++ b/cmdline/display.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cloudfoundry-community/pat/experiment"
+	"github.com/cloudfoundry-incubator/pat/experiment"
 )
 
 func display(concurrency int, iterations int, interval int, stop int, samples <-chan *experiment.Sample) {

--- a/config/config.go
+++ b/config/config.go
@@ -3,7 +3,7 @@ package config
 import (
 	"flag"
 	"io/ioutil"
-	"os"
+	"os"	
 
 	"launchpad.net/goyaml"
 )
@@ -79,7 +79,6 @@ func (f *f) Parse(args []string) error {
 			panic("Failed Parsing Config File")
 		}
 	}
-
 	return nil
 }
 
@@ -95,7 +94,7 @@ func (f *f) ParseEnv() error {
 	return nil
 }
 
-func (f *f) ParseConfig(path string) error {
+func (f *f) ParseConfig(path string) error {	
 	file, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	. "github.com/cloudfoundry-community/pat/config"
+	. "github.com/cloudfoundry-incubator/pat/config"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/context/context.go
+++ b/context/context.go
@@ -2,6 +2,8 @@ package context
 
 import (
 	"reflect"
+	"encoding/json"
+	"fmt"
 )
 
 type WorkloadContext interface{
@@ -15,6 +17,8 @@ type WorkloadContext interface{
 	GetFloat64(k string) float64
 	PutBool(k string, v bool)
 	GetBool(k string) bool
+	MarshalJSON() ([]byte, error)
+	Unmarshal(data []byte) error
 	CheckExists(k string) bool
 	CheckType(k string) string
 	Clone() WorkloadContent
@@ -24,6 +28,10 @@ type WorkloadContext interface{
 
 type WorkloadContent struct{
 	Content map[string]interface{}
+}
+
+func New() WorkloadContext {
+	return WorkloadContext( WorkloadContent{make(map[string]interface{})} )
 }
 
 func NewWorkloadContent() WorkloadContent {
@@ -76,6 +84,16 @@ func (c WorkloadContent) PutBool(k string, v bool) {
 
 func (c WorkloadContent) GetBool(k string) bool {
 	return c.Content[k].(bool)
+}
+
+func (c WorkloadContent) MarshalJSON() ([]byte, error) {
+	fmt.Println("**** called marshal")
+	return json.Marshal(c.Content)
+}
+
+func (c WorkloadContent) Unmarshal(data []byte) error {
+	fmt.Println("**** called Unmarshal")
+	return json.Unmarshal(data, &c.Content)	
 }
 
 func (c WorkloadContent) CheckExists(k string) bool {

--- a/context/context.go
+++ b/context/context.go
@@ -1,0 +1,111 @@
+package context
+
+import (
+	"reflect"
+)
+
+type WorkloadContext interface{
+	PutString(k string, v string)
+	GetString(k string) string
+	PutInt(k string, v int)
+	GetInt(k string) int
+	PutInt64(k string, v int64)
+	GetInt64(k string) int64
+	PutFloat64(k string, v float64)
+	GetFloat64(k string) float64
+	PutBool(k string, v bool)
+	GetBool(k string) bool
+	CheckExists(k string) bool
+	CheckType(k string) string
+	Clone() WorkloadContent
+	GetContent() WorkloadContent
+	GetKeys() []string
+}
+
+type WorkloadContent struct{
+	Content map[string]interface{}
+}
+
+func NewWorkloadContent() WorkloadContent {
+	return WorkloadContent{make(map[string]interface{})}
+}
+
+func (c WorkloadContent) PutString(k string, v string) {
+	c.Content[k] = v
+}
+
+func (c WorkloadContent) GetString(k string) string {
+	return c.Content[k].(string)
+}
+
+func (c WorkloadContent) PutInt(k string, v int) {
+	c.Content[k] = v
+}
+
+func (c WorkloadContent) GetInt(k string) int {
+	//json.Unmarsal put numbers as float64 into interface{}
+	if reflect.TypeOf(c.Content[k]).Name() == "float64" {	
+		c.Content[k] = int(c.Content[k].(float64))
+	}
+	return c.Content[k].(int)
+}
+
+func (c WorkloadContent) PutInt64(k string, v int64) {
+	c.Content[k] = v
+}
+
+func (c WorkloadContent) GetInt64(k string) int64 {
+	//json.Unmarsal put numbers as float64 into interface{}
+	if reflect.TypeOf(c.Content[k]).Name() == "float64" {
+		c.Content[k] = int64(c.Content[k].(float64))
+	}
+	return c.Content[k].(int64)
+}
+
+func (c WorkloadContent) PutFloat64(k string, v float64) {
+	c.Content[k] = v
+}
+
+func (c WorkloadContent) GetFloat64(k string) float64 {
+	return c.Content[k].(float64)
+}
+
+func (c WorkloadContent) PutBool(k string, v bool) {
+	c.Content[k] = v
+}
+
+func (c WorkloadContent) GetBool(k string) bool {
+	return c.Content[k].(bool)
+}
+
+func (c WorkloadContent) CheckExists(k string) bool {
+	if c.Content[k] == nil {
+		return false
+	} else {
+		return true
+	}
+}
+
+func (c WorkloadContent) CheckType(k string) string {
+	return reflect.TypeOf(c.Content[k]).Name()
+}
+
+func (c WorkloadContent) Clone() WorkloadContent {
+	var clone = WorkloadContent{make(map[string]interface{})}
+	for k, v := range c.Content {
+    	clone.Content[k] = v
+	}
+	return clone
+}
+
+func (c WorkloadContent) GetContent() WorkloadContent {
+	return c
+}
+
+func  (c WorkloadContent) GetKeys() []string {
+	var keys []string
+	for k, _ := range c.Content {
+    	keys = append(keys, k)
+	}
+	return keys
+}

--- a/context/context_suite_test.go
+++ b/context/context_suite_test.go
@@ -1,0 +1,13 @@
+package context
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestContext(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Context Suite")
+}

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -1,0 +1,103 @@
+package context
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+
+var _ = Describe("Context map", func() {
+
+	var (
+		content WorkloadContent
+		localContext WorkloadContext
+	)
+
+	JustBeforeEach(func() {
+		content = NewWorkloadContent()
+		localContext = WorkloadContext(content)
+	})
+
+	Context("String values in context map", func(){
+		It("uses a key to identify store fields", func(){
+			localContext.PutString("key1", "abc")
+			localContext.PutString("key2", "123")
+
+			Ω(localContext.GetString("key1")).Should(Equal("abc"))
+			Ω(localContext.GetString("key2")).Should(Equal("123"))
+		})
+		
+		It("can store string value as provided", func(){
+			localContext.PutString("str", "This is a long string \n")
+
+			Ω(localContext.GetString("str")).Should(Equal("This is a long string \n"))
+		})
+
+		It("can store int value as provided", func(){
+			localContext.PutInt("int", 123)
+
+			Ω(localContext.GetInt("int")).Should(Equal(123))
+		})
+
+		It("can store int64 value as provided", func(){
+			localContext.PutInt64("key", int64(10000))
+
+			Ω(localContext.GetInt64("key")).Should(Equal(int64(10000)))
+		})
+
+		It("can store bool value as provided", func(){
+			localContext.PutBool("key", true)
+
+			Ω(localContext.GetBool("key")).Should(Equal(true))
+		})
+
+		It("can store float64 value as provided", func(){
+			localContext.PutFloat64("key", float64(3.14))
+
+			Ω(localContext.GetFloat64("key")).Should(Equal(float64(3.14)))
+		})
+	})
+
+	Context("Checking existing fields", func(){
+		It("returns true for existing fields, and false for non-existing", func(){
+			localContext.PutString("key1", "some string")
+
+			Ω(localContext.CheckExists("key1")).Should(Equal(true))
+			Ω(localContext.CheckExists("key2")).Should(Equal(false))
+		})
+	})
+
+	Context("Checking Types", func(){
+		It("returns the type name of the field", func(){
+			localContext.PutFloat64("key", float64(3.14))
+
+			Ω(localContext.CheckType("key")).Should(Equal("float64"))
+		})
+	})
+
+	Context("Cloning map", func(){
+		It("returns a copy of the cloned context map", func(){
+			localContext.PutString("str1", "abc")
+			localContext.PutString("str2", "def")
+
+			cloned := localContext.Clone()
+
+			localContext.PutString("str1", "123")
+
+			Ω(localContext.GetString("str1")).Should(Equal("123"))
+			Ω(cloned.GetString("str1")).Should(Equal("abc"))
+		})
+	})
+
+	Context("Getting map keys", func(){
+		It("returns an array of key names", func(){
+			localContext.PutString("key", "some value")
+			localContext.PutString("key1", "some value")
+			localContext.PutString("key2", "some value")
+			localContext.PutString("key3", "some value")
+
+			Ω(localContext.GetKeys()).Should(Equal([]string{"key","key1","key2","key3"}))
+		})
+	})
+
+})

--- a/experiment/runner.go
+++ b/experiment/runner.go
@@ -3,7 +3,7 @@ package experiment
 import (
 	"math"
 	"time"
-	. "github.com/cloudfoundry-community/pat/benchmarker"
+	. "github.com/cloudfoundry-incubator/pat/benchmarker"
 )
 
 type SampleType int

--- a/experiment/runner.go
+++ b/experiment/runner.go
@@ -3,6 +3,8 @@ package experiment
 import (
 	"math"
 	"time"
+
+	"github.com/cloudfoundry-incubator/pat/context"
 	. "github.com/cloudfoundry-incubator/pat/benchmarker"
 )
 
@@ -75,7 +77,7 @@ type SamplableExperiment struct {
 }
 
 type Executable interface {
-	Execute(workloadCtx map[string]interface{})
+	Execute(workloadCtx context.WorkloadContext)
 }
 
 type Samplable interface {
@@ -98,7 +100,7 @@ func newRunningExperiment(iterations int, iterationResults chan IterationResult,
 	return &SamplableExperiment{iterations, iterationResults, workers, samples, quit}
 }
 
-func (config *RunnableExperiment) Run(tracker func(<-chan *Sample), workloadCtx map[string]interface{}) error {
+func (config *RunnableExperiment) Run(tracker func(<-chan *Sample), workloadCtx context.WorkloadContext) error {
 	iteration := make(chan IterationResult)
 	errors := make(chan error)
 	workers := make(chan int)
@@ -119,8 +121,8 @@ func (config *RunnableExperiment) Run(tracker func(<-chan *Sample), workloadCtx 
 	return nil
 }
 
-func (ex *ExecutableExperiment) Execute(workloadCtx map[string]interface{}) {
-	Execute(RepeatEveryUntil(ex.Interval, ex.Stop, func(map[string]interface{}) {
+func (ex *ExecutableExperiment) Execute(workloadCtx context.WorkloadContext) {
+	Execute(RepeatEveryUntil(ex.Interval, ex.Stop, func(context.WorkloadContext) {
 		ExecuteConcurrently(ex.Concurrency, Repeat(ex.Iterations, Counted(ex.workers, TimedWithWorker(ex.iteration, ex.Worker, ex.Workload))), workloadCtx)
 	}, ex.quit), workloadCtx)
 

--- a/experiment/runner_test.go
+++ b/experiment/runner_test.go
@@ -3,7 +3,7 @@ package experiment
 import (
 	"errors"
 	"time"
-	. "github.com/cloudfoundry-community/pat/benchmarker"
+	. "github.com/cloudfoundry-incubator/pat/benchmarker"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/experiment/runner_test.go
+++ b/experiment/runner_test.go
@@ -3,6 +3,8 @@ package experiment
 import (
 	"errors"
 	"time"
+
+	"github.com/cloudfoundry-incubator/pat/context"
 	. "github.com/cloudfoundry-incubator/pat/benchmarker"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -19,7 +21,7 @@ var _ = Describe("ExperimentConfiguration and Sampler", func() {
 			sample1      *Sample
 			sample2      *Sample
 			worker       Worker
-			workloadCtx  = make(map[string]interface{})
+			workloadCtx  = context.WorkloadContext( context.NewWorkloadContent() )
 		)
 
 		BeforeEach(func() {
@@ -299,6 +301,6 @@ func (s *DummySampler) Sample() {
 	s.sampleFunc(s)
 }
 
-func (e *DummyExecutor) Execute(workloadCtx map[string]interface{}) {
+func (e *DummyExecutor) Execute(workloadCtx context.WorkloadContext) {
 	e.executorFunc(e)
 }

--- a/experiment/runner_test.go
+++ b/experiment/runner_test.go
@@ -19,6 +19,7 @@ var _ = Describe("ExperimentConfiguration and Sampler", func() {
 			sample1      *Sample
 			sample2      *Sample
 			worker       Worker
+			workloadCtx  = make(map[string]interface{})
 		)
 
 		BeforeEach(func() {
@@ -46,11 +47,11 @@ var _ = Describe("ExperimentConfiguration and Sampler", func() {
 			}
 
 			got := make([]*Sample, 0)
-			config.Run(func(samples <-chan *Sample) {
+			config.Run(func(samples <-chan *Sample, ) {
 				for s := range samples {
 					got = append(got, s)
 				}
-			})
+			}, workloadCtx)
 
 			Ω(got).Should(HaveLen(2))
 		})
@@ -59,7 +60,7 @@ var _ = Describe("ExperimentConfiguration and Sampler", func() {
 			executorFunc = func(e *DummyExecutor) {}
 			sampleFunc = func(s *DummySampler) {}
 
-			config.Run(func(samples <-chan *Sample) {})
+			config.Run(func(samples <-chan *Sample) {}, workloadCtx)
 
 			Ω(sampler.maxIterations).Should(Equal(15))
 		})
@@ -83,7 +84,7 @@ var _ = Describe("ExperimentConfiguration and Sampler", func() {
 			config.Run(func(samples <-chan *Sample) {
 				for _ = range samples {
 				}
-			})
+			}, workloadCtx)
 			Ω(got).Should(HaveLen(3))
 		})
 
@@ -105,7 +106,7 @@ var _ = Describe("ExperimentConfiguration and Sampler", func() {
 			config.Run(func(samples <-chan *Sample) {
 				for _ = range samples {
 				}
-			})
+			}, workloadCtx)
 			Ω(got).Should(Equal([]int{2, -1}))
 		})
 
@@ -126,7 +127,7 @@ var _ = Describe("ExperimentConfiguration and Sampler", func() {
 			config.Run(func(samples <-chan *Sample) {
 				for _ = range samples {
 				}
-			})
+			}, workloadCtx)
 			Ω(got).Should(HaveLen(1))
 			Ω(got[0].Error()).Should(Equal("Foo"))
 		})		
@@ -298,6 +299,6 @@ func (s *DummySampler) Sample() {
 	s.sampleFunc(s)
 }
 
-func (e *DummyExecutor) Execute() {
+func (e *DummyExecutor) Execute(workloadCtx map[string]interface{}) {
 	e.executorFunc(e)
 }

--- a/features/basic_flow.coffee
+++ b/features/basic_flow.coffee
@@ -7,10 +7,10 @@ casper.test.begin 'Basic Flow', 6, (test) ->
     @previous_experiments_count = @evaluate previousExperimentCount
     @echo("Currently #{@.previous_experiments_count} experiments in the previous experiments list")
 
-    @fill 'form', 
-      inputExperiment: "dummy"
+    @fill 'form',       
       inputIterations: 7
-      inputConcurrency: 5
+      inputConcurrency: 5    
+    @click '#workloadItem-dummyWithErrors'
     @click 'button[type=submit]'
     @waitWhileVisible ".noexperimentrunning"
 

--- a/laboratory/laboratory.go
+++ b/laboratory/laboratory.go
@@ -3,6 +3,7 @@ package laboratory
 import (
 	"github.com/cloudfoundry-incubator/pat/experiment"
 	"github.com/nu7hatch/gouuid"
+	"github.com/cloudfoundry-incubator/pat/context"
 )
 
 type lab struct {
@@ -11,14 +12,14 @@ type lab struct {
 }
 
 type Laboratory interface {
-	Run(ex Runnable, workloadCtx map[string]interface{}) (string, error)
-	RunWithHandlers(ex Runnable, fns []func(samples <-chan *experiment.Sample), workloadCtx map[string]interface{}) (string, error)
+	Run(ex Runnable, workloadCtx context.WorkloadContext) (string, error)
+	RunWithHandlers(ex Runnable, fns []func(samples <-chan *experiment.Sample), workloadCtx context.WorkloadContext) (string, error)
 	Visit(fn func(ex experiment.Experiment))
 	GetData(name string) ([]*experiment.Sample, error)
 }
 
 type Runnable interface {
-	Run(handler func(samples <-chan *experiment.Sample), workloadCtx map[string]interface{}) error
+	Run(handler func(samples <-chan *experiment.Sample), workloadCtx context.WorkloadContext) error
 }
 
 type Store interface {
@@ -36,11 +37,11 @@ func (self *lab) reload() {
 	self.loaded, _ = self.store.LoadAll()
 }
 
-func (self *lab) Run(ex Runnable, workloadCtx map[string]interface{}) (string, error) {	
+func (self *lab) Run(ex Runnable, workloadCtx context.WorkloadContext) (string, error) {	
 	return self.RunWithHandlers(ex, make([]func(<-chan *experiment.Sample), 0), workloadCtx)
 }
 
-func (self *lab) RunWithHandlers(ex Runnable, additionalHandlers []func(<-chan *experiment.Sample), workloadCtx map[string]interface{}) (string, error) {
+func (self *lab) RunWithHandlers(ex Runnable, additionalHandlers []func(<-chan *experiment.Sample), workloadCtx context.WorkloadContext) (string, error) {
 	guid, _ := uuid.NewV4()
 	handlers := make([]func(<-chan *experiment.Sample), 1)
 	handlers[0] = self.store.Writer(guid.String())

--- a/laboratory/laboratory.go
+++ b/laboratory/laboratory.go
@@ -1,7 +1,7 @@
 package laboratory
 
 import (
-	"github.com/cloudfoundry-community/pat/experiment"
+	"github.com/cloudfoundry-incubator/pat/experiment"
 	"github.com/nu7hatch/gouuid"
 )
 

--- a/laboratory/laboratory.go
+++ b/laboratory/laboratory.go
@@ -11,14 +11,14 @@ type lab struct {
 }
 
 type Laboratory interface {
-	Run(ex Runnable) (string, error)
-	RunWithHandlers(ex Runnable, fns []func(samples <-chan *experiment.Sample)) (string, error)
+	Run(ex Runnable, workloadCtx map[string]interface{}) (string, error)
+	RunWithHandlers(ex Runnable, fns []func(samples <-chan *experiment.Sample), workloadCtx map[string]interface{}) (string, error)
 	Visit(fn func(ex experiment.Experiment))
 	GetData(name string) ([]*experiment.Sample, error)
 }
 
 type Runnable interface {
-	Run(handler func(samples <-chan *experiment.Sample)) error
+	Run(handler func(samples <-chan *experiment.Sample), workloadCtx map[string]interface{}) error
 }
 
 type Store interface {
@@ -36,18 +36,18 @@ func (self *lab) reload() {
 	self.loaded, _ = self.store.LoadAll()
 }
 
-func (self *lab) Run(ex Runnable) (string, error) {
-	return self.RunWithHandlers(ex, make([]func(<-chan *experiment.Sample), 0))
+func (self *lab) Run(ex Runnable, workloadCtx map[string]interface{}) (string, error) {	
+	return self.RunWithHandlers(ex, make([]func(<-chan *experiment.Sample), 0), workloadCtx)
 }
 
-func (self *lab) RunWithHandlers(ex Runnable, additionalHandlers []func(<-chan *experiment.Sample)) (string, error) {
+func (self *lab) RunWithHandlers(ex Runnable, additionalHandlers []func(<-chan *experiment.Sample), workloadCtx map[string]interface{}) (string, error) {
 	guid, _ := uuid.NewV4()
 	handlers := make([]func(<-chan *experiment.Sample), 1)
 	handlers[0] = self.store.Writer(guid.String())
 	for _, h := range additionalHandlers {
 		handlers = append(handlers, h)
 	}
-	go ex.Run(Multiplexer(handlers).Multiplex)
+	go ex.Run(Multiplexer(handlers).Multiplex, workloadCtx)
 	return guid.String(), nil
 }
 

--- a/laboratory/laboratory_test.go
+++ b/laboratory/laboratory_test.go
@@ -1,7 +1,7 @@
 package laboratory
 
 import (
-	. "github.com/cloudfoundry-community/pat/experiment"
+	. "github.com/cloudfoundry-incubator/pat/experiment"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/laboratory/laboratory_test.go
+++ b/laboratory/laboratory_test.go
@@ -16,6 +16,7 @@ var _ = Describe("Laboratory", func() {
 			run1            string
 			run2            string
 			handlerRecieved []*Sample
+			workloadCtx     = make(map[string]interface{})
 		)
 
 		BeforeEach(func() {
@@ -26,14 +27,14 @@ var _ = Describe("Laboratory", func() {
 			lab = NewLaboratory(store)
 			experiment1 = &dummyExperiment{"1", []*Sample{&Sample{}}}
 			experiment2 = &dummyExperiment{"2", []*Sample{&Sample{}, &Sample{}}}
-			run1, _ = lab.Run(experiment1)
+			run1, _ = lab.Run(experiment1, workloadCtx)
 
 			handlerRecieved = nil
 			run2, _ = lab.RunWithHandlers(experiment2, []func(<-chan *Sample){func(samples <-chan *Sample) {
 				for s := range samples {
 					handlerRecieved = append(handlerRecieved, s)
 				}
-			}})
+			}}, workloadCtx)
 
 			// wait for experiments to run
 			Eventually(func() int {
@@ -153,7 +154,7 @@ func (store *dummyStore) LoadAll() ([]Experiment, error) {
 	return store.previous, nil
 }
 
-func (e *dummyExperiment) Run(fn func(samples <-chan *Sample)) error {
+func (e *dummyExperiment) Run(fn func(samples <-chan *Sample), workloadCtx map[string]interface {}) error {
 	ch := make(chan *Sample)
 	done := make(chan bool)
 	go func() {

--- a/laboratory/laboratory_test.go
+++ b/laboratory/laboratory_test.go
@@ -1,6 +1,7 @@
 package laboratory
 
 import (
+	"github.com/cloudfoundry-incubator/pat/context"
 	. "github.com/cloudfoundry-incubator/pat/experiment"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -16,7 +17,7 @@ var _ = Describe("Laboratory", func() {
 			run1            string
 			run2            string
 			handlerRecieved []*Sample
-			workloadCtx     = make(map[string]interface{})
+			workloadCtx     = context.NewWorkloadContent()
 		)
 
 		BeforeEach(func() {
@@ -154,7 +155,7 @@ func (store *dummyStore) LoadAll() ([]Experiment, error) {
 	return store.previous, nil
 }
 
-func (e *dummyExperiment) Run(fn func(samples <-chan *Sample), workloadCtx map[string]interface {}) error {
+func (e *dummyExperiment) Run(fn func(samples <-chan *Sample), workloadCtx context.WorkloadContext) error {
 	ch := make(chan *Sample)
 	done := make(chan bool)
 	go func() {

--- a/laboratory/multiplex.go
+++ b/laboratory/multiplex.go
@@ -1,7 +1,7 @@
 package laboratory
 
 import (
-	"github.com/cloudfoundry-community/pat/experiment"
+	"github.com/cloudfoundry-incubator/pat/experiment"
 )
 
 type Multiplexer []func(<-chan *experiment.Sample)

--- a/logs/config.go
+++ b/logs/config.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/cloudfoundry-community/pat/config"
+	"github.com/cloudfoundry-incubator/pat/config"
 	"github.com/cloudfoundry/gosteno"
 )
 

--- a/logs/logs_test.go
+++ b/logs/logs_test.go
@@ -3,7 +3,7 @@ package logs
 import (
 	"os"
 
-	"github.com/cloudfoundry-community/pat/config"
+	"github.com/cloudfoundry-incubator/pat/config"
 	"github.com/cloudfoundry/gosteno"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/main.go
+++ b/main.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cloudfoundry-community/pat/cmdline"
-	"github.com/cloudfoundry-community/pat/config"
-	"github.com/cloudfoundry-community/pat/logs"
-	"github.com/cloudfoundry-community/pat/server"
+	"github.com/cloudfoundry-incubator/pat/cmdline"
+	"github.com/cloudfoundry-incubator/pat/config"
+	"github.com/cloudfoundry-incubator/pat/logs"
+	"github.com/cloudfoundry-incubator/pat/server"
 )
 
 func main() {

--- a/package.json
+++ b/package.json
@@ -1,3 +1,6 @@
 {
-  "name": "pats"
+	"name": "pats",
+ 	"dependencies": {
+	  "jQuery": "~1.7.4"
+	}
 }

--- a/redis/config.go
+++ b/redis/config.go
@@ -3,7 +3,7 @@ package redis
 import (
 	"encoding/json"
 
-	"github.com/cloudfoundry-community/pat/config"
+	"github.com/cloudfoundry-incubator/pat/config"
 )
 
 var params = struct {

--- a/redis/config_test.go
+++ b/redis/config_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"os"
 
-	"github.com/cloudfoundry-community/pat/config"
+	"github.com/cloudfoundry-incubator/pat/config"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/redis/conn.go
+++ b/redis/conn.go
@@ -3,7 +3,7 @@ package redis
 import (
 	"fmt"
 
-	"github.com/cloudfoundry-community/pat/logs"
+	"github.com/cloudfoundry-incubator/pat/logs"
 	"github.com/garyburd/redigo/redis"
 )
 

--- a/redis/conn_test.go
+++ b/redis/conn_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"time"
-	. "github.com/cloudfoundry-community/pat/redis"
+	. "github.com/cloudfoundry-incubator/pat/redis"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/server/server.go
+++ b/server/server.go
@@ -135,7 +135,7 @@ func (ctx *serverContext) handlePush(w http.ResponseWriter, r *http.Request) (in
 		workload = "gcf:push"
 	}
 
-	workloadContext := context.WorkloadContext( context.NewWorkloadContent() )
+	workloadContext := context.New()
 
 	workloadContext.PutString("cfTarget", cfTarget)
 	workloadContext.PutString("cfUsername", cfUsername)

--- a/server/server.go
+++ b/server/server.go
@@ -127,8 +127,8 @@ func (ctx *context) handlePush(w http.ResponseWriter, r *http.Request) (interfac
 
 	cfTarget := removeSpaces( r.FormValue("cfTarget") )
 	cfUsername := removeSpaces( r.FormValue("cfUsername") )
-	cfPassword := removeSpaces( r.FormValue("cfPassword") )
 	workload := removeSpaces( r.FormValue("workload") )
+	cfPassword := r.FormValue("cfPassword")
 
 	if workload == "" {
 		workload = "gcf:push"
@@ -198,10 +198,6 @@ func handler(fn func(http.ResponseWriter, *http.Request) (interface{}, error)) h
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	}
-}
-
-func removeSpaces(value string) string {
-	return strings.Replace(value, " ", "", -1)
 }
 
 var ListenAndServe = func(bind string) error {

--- a/server/server.go
+++ b/server/server.go
@@ -8,12 +8,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cloudfoundry-community/pat/benchmarker"
-	"github.com/cloudfoundry-community/pat/config"
-	. "github.com/cloudfoundry-community/pat/experiment"
-	. "github.com/cloudfoundry-community/pat/laboratory"
-	"github.com/cloudfoundry-community/pat/logs"
-	"github.com/cloudfoundry-community/pat/store"
+	"github.com/cloudfoundry-incubator/pat/benchmarker"
+	"github.com/cloudfoundry-incubator/pat/config"
+	. "github.com/cloudfoundry-incubator/pat/experiment"
+	. "github.com/cloudfoundry-incubator/pat/laboratory"
+	"github.com/cloudfoundry-incubator/pat/logs"
+	"github.com/cloudfoundry-incubator/pat/store"
 	"github.com/gorilla/mux"
 )
 
@@ -198,6 +198,10 @@ func handler(fn func(http.ResponseWriter, *http.Request) (interface{}, error)) h
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	}
+}
+
+func removeSpaces(value string) string {
+	return strings.Replace(value, " ", "", -1)
 }
 
 var ListenAndServe = func(bind string) error {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -185,10 +185,6 @@ var _ = Describe("Server", func() {
 		Ω(workloadCtxStringValue("cfPassword")).Should(Equal("pass1"))
 	})
 
-	It("removes space in 'cfPassword' parameter", func() {
-		post("/experiments/?cfPassword=pass1, pass2, pass3")
-		Ω(workloadCtxStringValue("cfPassword")).Should(Equal("pass1,pass2,pass3"))
-	})
 })
 
 type DummyLab struct {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -8,12 +8,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/cloudfoundry-community/pat/config"
-	. "github.com/cloudfoundry-community/pat/experiment"
-	. "github.com/cloudfoundry-community/pat/laboratory"
-	. "github.com/cloudfoundry-community/pat/server"
-	"github.com/cloudfoundry-community/pat/store"
-	"github.com/cloudfoundry-community/pat/workloads"
+	"github.com/cloudfoundry-incubator/pat/config"
+	. "github.com/cloudfoundry-incubator/pat/experiment"
+	. "github.com/cloudfoundry-incubator/pat/laboratory"
+	. "github.com/cloudfoundry-incubator/pat/server"
+	"github.com/cloudfoundry-incubator/pat/store"
+	"github.com/cloudfoundry-incubator/pat/workloads"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/store/config.go
+++ b/store/config.go
@@ -1,10 +1,10 @@
 package store
 
 import (
-	"github.com/cloudfoundry-community/pat/config"
-	"github.com/cloudfoundry-community/pat/laboratory"
-	"github.com/cloudfoundry-community/pat/redis"
-	"github.com/cloudfoundry-community/pat/workloads"
+	"github.com/cloudfoundry-incubator/pat/config"
+	"github.com/cloudfoundry-incubator/pat/laboratory"
+	"github.com/cloudfoundry-incubator/pat/redis"
+	"github.com/cloudfoundry-incubator/pat/workloads"
 )
 
 var params = struct {

--- a/store/config_test.go
+++ b/store/config_test.go
@@ -1,10 +1,10 @@
 package store_test
 
 import (
-	"github.com/cloudfoundry-community/pat/config"
-	"github.com/cloudfoundry-community/pat/laboratory"
-	"github.com/cloudfoundry-community/pat/redis"
-	. "github.com/cloudfoundry-community/pat/store"
+	"github.com/cloudfoundry-incubator/pat/config"
+	"github.com/cloudfoundry-incubator/pat/laboratory"
+	"github.com/cloudfoundry-incubator/pat/redis"
+	. "github.com/cloudfoundry-incubator/pat/store"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/store/csv.go
+++ b/store/csv.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cloudfoundry-community/pat/experiment"
-	"github.com/cloudfoundry-community/pat/logs"
-	"github.com/cloudfoundry-community/pat/workloads"
+	"github.com/cloudfoundry-incubator/pat/experiment"
+	"github.com/cloudfoundry-incubator/pat/logs"
+	"github.com/cloudfoundry-incubator/pat/workloads"
 )
 
 type CsvStore struct {

--- a/store/csv_test.go
+++ b/store/csv_test.go
@@ -8,9 +8,9 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/cloudfoundry-community/pat/experiment"
-	. "github.com/cloudfoundry-community/pat/store"
-	"github.com/cloudfoundry-community/pat/workloads"
+	"github.com/cloudfoundry-incubator/pat/experiment"
+	. "github.com/cloudfoundry-incubator/pat/store"
+	"github.com/cloudfoundry-incubator/pat/workloads"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/store/redis.go
+++ b/store/redis.go
@@ -3,8 +3,8 @@ package store
 import (
 	"encoding/json"
 
-	"github.com/cloudfoundry-community/pat/experiment"
-	"github.com/cloudfoundry-community/pat/redis"
+	"github.com/cloudfoundry-incubator/pat/experiment"
+	"github.com/cloudfoundry-incubator/pat/redis"
 )
 
 const MAX_RESULTS = 10000

--- a/store/redis_test.go
+++ b/store/redis_test.go
@@ -7,9 +7,9 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/cloudfoundry-community/pat/experiment"
-	"github.com/cloudfoundry-community/pat/redis"
-	. "github.com/cloudfoundry-community/pat/store"
+	"github.com/cloudfoundry-incubator/pat/experiment"
+	"github.com/cloudfoundry-incubator/pat/redis"
+	. "github.com/cloudfoundry-incubator/pat/store"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/ui/index.html
+++ b/ui/index.html
@@ -14,6 +14,7 @@
 <script type="text/javascript" src="js/chart.js"></script>
 <script type="text/javascript" src="js/bar.js"></script>
 <script type="text/javascript" src="js/throughput.js"></script>
+<script type="text/javascript" src="js/workloadList.js"></script>
 <script type="text/javascript" src="js/dom.js"></script>
 <script type="text/javascript" src="js/app.js"></script>
 <title>Cloud Foundry Performance Suite</title>
@@ -89,56 +90,58 @@ body { padding: 8px; }
     <div class="modal-dialog" style="width: 90%; max-width: 900px;">
       <div class="modal-content" style="background:rgba(255,255,255,0.75);">
         <div class="modal-header">
-          <button id="btnExperimentClose" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+          <button id="btnExperimentClose" type="button" class="close" aria-hidden="true">&times;</button>
           <h4 class="modal-title">Experiment Configuration</h4>
         </div>
-        <div class="panel-body">
-          <form class="form-horizontal" role="form">
-            <div class="form-group">
-              <label for="inputExperiment" class="col-sm-2 control-label">Workload</label>
-              <div class="col-sm-6">
-                <select id="cmdSelect" name="inputExperiment" class="form-control">
-                  <option value="gcf:push">Simple Push</option>
-                  <option value="dummy,dummyWithErrors">Dummies (dummy, dummyWithErrors)</option>            
-                  <option value="dummy">Dummy Push</option>
-                  <option value="gcf:push,gcf:push">Multiple Pushes</option>
-                  <option value="dummyWithErrors">Dummy with Errors</option>
-                </select>
-              </div>
-            </div>
-            <div class="form-group" data-bind="css: { 'has-error': numIterationsHasError }">
-              <label for="inputIterations" class="col-sm-2 control-label">Iterations</label>
-              <div class="col-sm-6">
-                <input type="number" class="form-control" id="inputIterations" name="inputIterations" placeholder="1" data-bind="value: numIterations">
-              </div>
-            </div>
-            <div class="form-group" data-bind="css: { 'has-error': numConcurrentHasError }">
-              <label for="inputConcurrency" class="col-sm-2 control-label">Concurrency</label>
-              <div class="col-sm-6">
-                <input type="number" class="form-control" id="inputConcurrency" name="inputConcurrency" placeholder="1" data-bind="value: numConcurrent">
-              </div>
-            </div>
-            <div class="form-group" data-bind="css: { 'has-error': numIntervalHasError }">
-              <label for="inputInterval" class="col-sm-2 control-label">Interval</label>
-              <div class="col-sm-6">
-                <input type="number" class="form-control" id="inputInterval" name="inputInterval" placeholder="0" data-bind="value: numInterval">
-              </div>
-            </div>
-            <div class="form-group" data-bind="css: { 'has-error': numStopHasError }">
-              <label for="inputStop" class="col-sm-2 control-label">Stop</label>
-              <div class="col-sm-6">
-                <input type="number" class="form-control" id="inputStop" name="inputStop" placeholder="0" data-bind="value: numStop">
-              </div>
-            </div>
-            <div class="form-group">
-              <div class="col-sm-offset-2 col-sm-10">
-                <button data-bind="click: start, enable: formHasNoErrors" id="startbtn" type="submit" data-dismiss="modal" class="btn btn-primary navbar-btn"><span class="glyphicon glyphicon-play"></span> Start Experiment</button>
-              </div>
-            </div>
-          </form>
-        </div>
-      </div>
-    </div>
+	    <div class="panel-body">
+    	  <form class="form-horizontal" role="form">
+        	<div class="form-group">
+	          <label for="workloadItems" class="col-sm-2 control-label">Workload Items</label>          
+    	      <div id="workloadItems" class="col-sm-6"></div>
+        	</div>
+	        <div class="form-group">
+    	      <label for="selectedList" class="col-sm-2 control-label">Selected Workload</label>          
+        	  <div id="selectedList" class="col-sm-6"></div>
+	        </div>
+    	    <div class="form-group">
+	          <label class="col-sm-2 control-label">Workload Arguments</label>                   
+    	      <div class="col-sm-6">
+        	    <div id="argumentList" class="form-horizontal" role="form"></div>
+	          </div>            
+    	    </div>        
+        	<div class="form-group" data-bind="css: { 'has-error': numIterationsHasError }">
+	          <label for="inputIterations" class="col-sm-2 control-label">Iterations</label>
+    	      <div class="col-sm-6">
+        	    <input type="number" class="form-control" id="inputIterations" name="inputIterations" placeholder="1" data-bind="value: numIterations">
+	          </div>
+	        </div>
+	        <div class="form-group" data-bind="css: { 'has-error': numConcurrentHasError }">
+    	      <label for="inputConcurrency" class="col-sm-2 control-label">Concurrency</label>
+        	  <div class="col-sm-6">
+            	<input type="number" class="form-control" id="inputConcurrency" name="inputConcurrency" placeholder="1" data-bind="value: numConcurrent">
+	          </div>
+    	    </div>
+        	<div class="form-group" data-bind="css: { 'has-error': numIntervalHasError }">
+	          <label for="inputInterval" class="col-sm-2 control-label">Interval</label>
+    	      <div class="col-sm-6">
+        	    <input type="number" class="form-control" id="inputInterval" name="inputInterval" placeholder="0" data-bind="value: numInterval">
+	          </div>
+    	    </div>
+        	<div class="form-group" data-bind="css: { 'has-error': numStopHasError }">
+	          <label for="inputStop" class="col-sm-2 control-label">Stop</label>
+    	      <div class="col-sm-6">
+        	    <input type="number" class="form-control" id="inputStop" name="inputStop" placeholder="0" data-bind="value: numStop">
+	          </div>
+    	    </div>
+        	<div class="form-group">
+	          <div class="col-sm-offset-2 col-sm-10">
+    	        <button data-bind="click: start, enable: formHasNoErrors" id="startbtn" type="submit" data-dismiss="modal" class="btn btn-primary navbar-btn"><span class="glyphicon glyphicon-play"></span> Start Experiment</button>
+	          </div>
+    	    </div>
+	      </form>
+		</div>
+	  </div>	
+	</div>
   </div>
 
   <div class="modal fade" id="historyPopup" tabindex="-1" role="dialog" aria-labelledby="historyPopupLabel" aria-hidden="true" >
@@ -146,7 +149,7 @@ body { padding: 8px; }
       <div class="modal-content" style="background:rgba(255,255,255,0.75);">
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-          <h4 class="modal-title" >Previous Experiment</h4>
+          <h4 class="modal-title" >Previous Experiments</h4>
         </div>
         <div class="modal-body">
           <table class="table table-hover">
@@ -174,7 +177,7 @@ body { padding: 8px; }
     </div>
   </div>
 
-  <script>
+  <script>    
     ko.applyBindings(new pat.view( new pat.experimentList(), pat.experiment(800) ));
   </script>
 </div>

--- a/ui/js/workloadList.js
+++ b/ui/js/workloadList.js
@@ -1,0 +1,254 @@
+patWorkload = function(workloadNode, selectedNode, commandArgsNode){
+
+	const workloadItems = {
+	"rest:target": {
+		requires: [],
+		requiredBy: [
+			"rest:login",
+			"rest:push"
+		],
+		args: [
+			"rest:target"
+		]	
+	},
+	"rest:login": {		
+		requires: [
+			"rest:target"
+		],
+		requiredBy: [
+			"rest:push"
+		],
+		args: [
+			"rest:username",
+			"rest:password"
+		]
+	},
+	"rest:push": {
+		requires: [
+			"rest:target",
+			"rest:login"
+		],
+		requiredBy: [],
+		args: []
+	},
+	"gcf:push": {
+		requires: [],
+		requiredBy: [],
+		args: []	
+	},
+	"dummy": {
+		requires: [],
+		requiredBy: [],
+		args: []	
+	},
+	"dummyWithErrors": {
+		requires: [],
+		requiredBy: [],
+		args: []	
+	}};
+
+	const argumentItems = {
+	"rest:target": {
+			koBind: "",
+			errCheckFn: "",
+			regex: /^(?:https?:\/\/(?:www\.)?|www\.)[a-z0-9]+(?:[-.][a-z0-9]+)*\.[a-z]{2,5}(?::[0-9]{1,5})?(?:\/\S*)?$/,
+			requiredBy: ["rest:target"],
+			default: "http://xio.10.xx.xx.xx"
+	},
+	"rest:username": {
+			koBind: "",
+			errCheckFn: "",
+			regex: /^[a-zA-Z0-9-_,]+$/,
+			default: "admin",
+			requiredBy: ["rest:login"]			
+	},
+	"rest:password": {
+			koBind: "",
+			errCheckFn: "",
+			regex: /^[a-zA-Z0-9-_,]+$/,
+			default: "admin",
+			requiredBy: ["rest:login"]
+	}};
+
+	var workloadBtns  = {};
+	var commandArgs = {};
+	var selectedWorkloads  = [];
+	var workloadsObservableFn;
+
+	$(workloadNode).html('')
+	$(selectedNode).html('')
+	$(commandArgsNode).html('')
+
+	// draw workload buttons
+	for (var cmd in workloadItems) {
+		workloadBtns[cmd] = $("<button>", {
+			"type": "button",
+			"id": "workloadItem-" + cmd,
+			"click": function(e) { addWorkloadBtn(e) }, 
+			"class": "btn btn-default",			
+			"html": '<span class="glyphicon glyphicon-plus-sign"></span> ' + cmd
+		})									
+		workloadBtns[cmd].appendTo($(workloadNode))
+		$(workloadNode).append(" ")		
+	}
+	
+	var workloads = function() {
+		var str = ""
+		selectedWorkloads.forEach (function(d) {			
+			str = str + ((str == "")? d.cmd : "," + d.cmd)
+		})		
+		return str;
+	}
+
+	var importKoBindingsVars = function(target, targetErrFn, username, usernameErrFn, password, passwordErrFn) {
+		argumentItems["rest:target"].koBind = target;
+		argumentItems["rest:username"].koBind = username;
+		argumentItems["rest:password"].koBind = password;
+		argumentItems["rest:target"].errCheckFn = targetErrFn;
+		argumentItems["rest:username"].errCheckFn = usernameErrFn;
+		argumentItems["rest:password"].errCheckFn = passwordErrFn;
+		drawArgumentInputs()
+	}
+
+	var isArgumentError = function(arg, value) {
+		if (commandArgs[arg].css("display") == "none") return false;
+		
+		if (value.trim() == "") return true;
+
+		return !(argumentItems[arg].regex.test(value))
+	}
+
+	var workloadsObservable = function(ob) {
+		workloadsObservableFn = ob;
+	}
+
+	return {		
+		workloads: workloads,		
+		workloadsObservable: workloadsObservable,
+		importKoBindingsVars: importKoBindingsVars,
+		isArgumentError: isArgumentError,
+		workloadItems: workloadItems
+	};	
+
+	function drawArgumentInputs() {
+		for (var cmd in argumentItems) {
+			var input = $("<div>", {
+					"class": "col-sm-8",
+					"html" : '<input type="text" class="form-control" data-bind="value: ' + argumentItems[cmd].koBind + '">'
+				})
+				var label = $("<label>", {					
+					"class" : "col-sm-3 control-label",
+					"html"  : cmd
+				})
+				commandArgs[cmd] = $("<div>", {
+					"class" : "form-group",
+					"data-bind": "css: { 'has-error': " + argumentItems[cmd].errCheckFn + " }",
+					"style": "display: none"
+				})
+
+				label.appendTo(commandArgs[cmd])
+				input.appendTo(commandArgs[cmd])
+				commandArgs[cmd].appendTo($(commandArgsNode))
+		}
+	}
+
+	function addWorkloadBtn(e) {
+		var cmd = (e.target.innerText.trim()=="")? e.target.parentNode.innerText.trim() : e.target.innerText.trim();
+		// first add the required commands
+		workloadItems[cmd].requires.forEach(function(d){
+			if (findIndexByCommand(d) == -1) appendWorkloadBtnToDom(d)
+		})
+		appendWorkloadBtnToDom(cmd)
+	}
+
+	function appendWorkloadBtnToDom(cmd) {
+		var btn = {};				
+		btn = $("<button>", {
+			"type" : "button", 			
+			"click": function(e) { removeWorkloadItem(btn) },
+			"class": "btn btn-link " + cmd,
+			"html" : '<span class="glyphicon glyphicon-minus-sign"></span> ' + cmd
+		});
+		btn.cmd = cmd;					
+		btn.appendTo( $(selectedNode) );
+		selectedWorkloads.push(btn);
+
+		workloadItems[cmd].args.forEach(function(d) {
+			commandArgs[d].css("display", "inherit")
+		})
+
+		if (workloadsObservableFn) workloadsObservableFn(workloads());
+	}
+
+	function addCommandArgs(cmd) {
+		if (commandArgs[cmd] != null) return;
+			var input = $("<div>", {
+				"class": "col-sm-8",
+				"html" : '<input type="text" placeHolder="' + cmd + '" class="form-control" data-bind="value: cfTarget">'
+			})
+			var label = $("<label>", {
+				"for"   : "args:" + cmd,
+				"class" : "col-sm-3 control-label",
+				"html"  : cmd
+			})
+			commandArgs[cmd] = $("<div>", {
+				"class" : "form-group",
+				"data-bind": "css: { 'has-error': targetHasError }"
+			})
+
+			label.appendTo(commandArgs[cmd])
+			input.appendTo(commandArgs[cmd])
+			commandArgs[cmd].appendTo($(commandArgsNode))
+	}
+
+	function removeWorkloadItem(btn) {
+		var warning = "";
+		var duplicatedCmd = (findIndexByCommand(btn.cmd, 0, findIndexByElement(btn)) == -1)? false : true;
+		
+		//first find any requiredBy commands
+		if (!duplicatedCmd) {
+			workloadItems[btn.cmd].requiredBy.forEach(function(d) {
+				if (findIndexByCommand(d, findIndexByElement(btn)) != -1) {
+					warning = (warning == "")? d : warning + ", " + d;
+				}
+			})			
+		}
+
+		if (warning != "") {
+			alert("Cannot remove item\nIt is required by [" + warning + "]");
+			return;
+		} 
+
+		var index = findIndexByElement(btn);
+		selectedWorkloads[index].remove();
+		selectedWorkloads.splice(index, 1);
+
+		if (!duplicatedCmd) {
+			//need to hide required arguments when item is removed				
+			workloadItems[btn.cmd].args.forEach(function(d) {
+				commandArgs[d].css("display", "none")
+			})
+		}
+
+		if (workloadsObservableFn) workloadsObservableFn(workloads());
+	}
+
+	function findIndexByElement (btn) {
+		for (var i=0; i < selectedWorkloads.length; i++) {
+			if (selectedWorkloads[i] === btn) return i;
+		}
+		return -1;
+	}
+
+	function findIndexByCommand (cmd, start, end) {
+		start = (start >= 0)? start : 0;
+		end = ( end >= 0)? end : selectedWorkloads.length;
+		for (var i = start; i < end; i++) {
+			if (selectedWorkloads[i].cmd == cmd) return i;
+		}
+		return -1;
+	}
+	
+}
+
+

--- a/ui/test.html
+++ b/ui/test.html
@@ -12,6 +12,10 @@
 
     <!-- move the testing div out of the viewable area -->
     <div id="target" style="width: 800px; height: 400px; position: absolute; top: -1000px"></div>
+    <!-- divs for populating the workload list buttons -->
+    <div id="workloadItems" style="width: 800px; height: 200px; position: absolute; top: -1000px"></div>
+    <div id="selectedList" style="width: 800px; height: 200px; position: absolute; top: -1000px"></div>
+    <div id="argumentList" style="width: 800px; height: 200px; position: absolute; top: -1000px"></div>
 
     <button class="btn btn-primary btn-xs" style="position: absolute; top: -1000px" data-toggle="modal" data-target="#historyPopup">Histories</button> 
     <button class="btn btn-primary btn-xs" style="position: absolute; top: -1000px" data-toggle="modal" data-target="#experimentPopup">Histories</button> 
@@ -41,6 +45,7 @@
     <script src="js/chart.js"></script>
     <script src="js/throughput.js"></script>
     <script src="js/bar.js"></script>
+    <script src="js/workloadList.js"></script>
     <script src="js/app.js"></script>
     <script src="js/dom.js"></script>    
     <script src="js/tests.js"></script>

--- a/workloads/client.go
+++ b/workloads/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"fmt"
 
 	"github.com/cloudfoundry-incubator/pat/logs"
 )
@@ -42,6 +43,7 @@ func (client rest) MultipartPut(token string, m *multipart.Writer, url string, d
 }
 
 func (client rest) Get(token string, url string, data interface{}, body interface{}) Reply {
+	fmt.Println("in rest get")
 	return client.req(token, "GET", url, "", "", "", jsonToString(data), body)
 }
 

--- a/workloads/client.go
+++ b/workloads/client.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/url"
 	"strings"
 
-	"github.com/cloudfoundry-community/pat/logs"
+	"github.com/cloudfoundry-incubator/pat/logs"
 )
 
 type httpclient interface {
@@ -112,13 +113,15 @@ func (client rest) req(token string, method string, url string, contentType stri
 
 	var logger = logs.NewLogger("workloads.rest")
 
+	resp_body, _ := ioutil.ReadAll(resp.Body)
+	
 	if TRACE_REST_CALLS {
 		body := make(map[string]interface{})
-		json.NewDecoder(resp.Body).Decode(&body)
+		json.Unmarshal(resp_body, &body)
 		logger.Debug1f(">> %s", body)
 	}
 
-	err = json.NewDecoder(resp.Body).Decode(&reply)
+	json.Unmarshal(resp_body, &reply)
 	logger.Debug1f("%s %s %s", method, url, resp.Status)
 	return Reply{resp.StatusCode, resp.Status, resp.Header.Get("Location")}
 }

--- a/workloads/gcf_test.go
+++ b/workloads/gcf_test.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"strings"
 
-	. "github.com/cloudfoundry-community/pat/workloads"
+	. "github.com/cloudfoundry-incubator/pat/workloads"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/workloads/rest.go
+++ b/workloads/rest.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cloudfoundry-community/pat/config"
+	"github.com/cloudfoundry-incubator/pat/config"
 	"github.com/nu7hatch/gouuid"
 )
 

--- a/workloads/rest_test.go
+++ b/workloads/rest_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Rest Workloads", func() {
 		context           map[string]interface{}
 	)
 
-	BeforeEach(func() {
+	BeforeEach(func() {		
 		replies = make(map[string]interface{})
 		replyWithLocation = make(map[string]string)
 		client = &dummyClient{replies, replyWithLocation, make(map[call]interface{})}

--- a/workloads/rest_test.go
+++ b/workloads/rest_test.go
@@ -6,8 +6,8 @@ import (
 	"mime/multipart"
 	"net/url"
 
-	"github.com/cloudfoundry-community/pat/config"
-	. "github.com/cloudfoundry-community/pat/workloads"
+	"github.com/cloudfoundry-incubator/pat/config"
+	. "github.com/cloudfoundry-incubator/pat/workloads"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -29,7 +29,7 @@ var _ = Describe("Rest Workloads", func() {
 		context           map[string]interface{}
 	)
 
-	BeforeEach(func() {		
+	BeforeEach(func() {
 		replies = make(map[string]interface{})
 		replyWithLocation = make(map[string]string)
 		client = &dummyClient{replies, replyWithLocation, make(map[call]interface{})}

--- a/workloads/workloads.go
+++ b/workloads/workloads.go
@@ -2,6 +2,7 @@ package workloads
 
 import (
 	"github.com/cloudfoundry-incubator/pat/config"
+	"github.com/cloudfoundry-incubator/pat/context"
 )
 
 type WorkloadAdder interface {
@@ -10,7 +11,7 @@ type WorkloadAdder interface {
 
 type WorkloadStep struct {
 	Name        string
-	Fn          func(context map[string]interface{}) error
+	Fn          func(context.WorkloadContext) error
 	Description string
 }
 
@@ -33,10 +34,10 @@ func DefaultWorkloadList() *WorkloadList {
 }
 
 func Step(name string, fn func() error, description string) WorkloadStep {
-	return WorkloadStep{name, func(ctx map[string]interface{}) error { return fn() }, description}
+	return WorkloadStep{name, func(ctx context.WorkloadContext) error { return fn() }, description}
 }
 
-func StepWithContext(name string, fn func(map[string]interface{}) error, description string) WorkloadStep {
+func StepWithContext(name string, fn func(context.WorkloadContext) error, description string) WorkloadStep {
 	return WorkloadStep{name, fn, description}
 }
 

--- a/workloads/workloads.go
+++ b/workloads/workloads.go
@@ -1,7 +1,7 @@
 package workloads
 
 import (
-	"github.com/cloudfoundry-community/pat/config"
+	"github.com/cloudfoundry-incubator/pat/config"
 )
 
 type WorkloadAdder interface {


### PR DESCRIPTION
Web UI is now possible to specify a list of operations to run a custom experiment and it also prevents user to create an invalid experiment.
- I don't quite like the arrangement of the configuration box now, what we have will do for now, but I will re-arrange the inputs at a later time so it will be more pleasant to look at
