### PR TITLE
improve screen estate for content

### DIFF
--- a/ui/css/app.css
+++ b/ui/css/app.css
@@ -11,6 +11,20 @@ tr, td {
   padding:0;
 }
 
+.patTitle {
+  width: 550px;
+  position: absolute;
+  left:50%;
+  top: 0px;
+  text-shadow: 0 1px 0 #555;
+  margin-left: -275px;
+  color: #aaa;
+  text-shadow: 0 1px 0 #fff;
+  text-align: center;
+  font-size: 20pt;
+  text-transform: uppercase;
+}
+
 .popover{ /* overwrite the max width for bootstrap popover */
     max-width: 650px;
 }

--- a/ui/index.html
+++ b/ui/index.html
@@ -28,24 +28,17 @@ body { padding: 8px; }
 </head>
 
 <body>
-
 <div class="container">
-  <div class="header row">
-    <h1>Performance Acceptance Tests <small>v0.1</small></h1>
-  </div>
-
-  <div class="row">
-  </div>
-
   <div class="row panel panel-default">
     <div class="panel-heading">
-      <button class="btn btn-primary btn-xs" style="float: right" data-toggle="modal" data-target="#historyPopup">
-        <span class="glyphicon glyphicon-time"></span> Histories
+      <h3 class=" patTitle">Performance Acceptance Tests</h3>
+      <button class="btn btn-default btn-sm" style="float: right" data-toggle="modal" data-target="#historyPopup">
+        <span class="glyphicon glyphicon-time"></span> Histories ...
       </button>
-      <button class="btn btn-primary btn-xs" data-toggle="modal" data-target="#experimentPopup">
-        <span class="glyphicon glyphicon-flash"></span> Run Experiment..
+      <button class="btn btn-primary btn-sm" data-toggle="modal" data-target="#experimentPopup">
+        <span class="glyphicon glyphicon-flash"></span> Run Experiment ...
       </button>
-    </div>
+    </div>    
     <div id="graph" class="panel-body col-md-12 center-block" data-bind="chart: data" style="">
       <div class="btn-group-vertical" style="position:absolute; left:-60px; top: 15px;">
         <button type="button" data-bind="click: showWorkload, css: {'btn-default': workloadVisible}" class="btn btn-default btn-lg" style="border-top-right-radius: 0; border-right: 0">


### PR DESCRIPTION
Removed the large "PAT" title and made the control buttons a little bigger.

This allows more screen space for contents
