### PR TITLE
Correct interface for Gomega Match

### DIFF
--- a/cmdline/cmdline_test.go
+++ b/cmdline/cmdline_test.go
@@ -127,7 +127,7 @@ func HaveBeenRunWith(field string, value interface{}) OmegaMatcher {
 	return &runWithMatcher{field, value, nil}
 }
 
-func (m *runWithMatcher) Match(actualLab interface{}) (bool, error) {
+func (m *runWithMatcher) Match(actualLab interface{}) (bool, string, error) {
 	runWith := actualLab.(*dummyLab).lastRunWith
 	var actual interface{}
 	switch m.field {


### PR DESCRIPTION
ginkgo in /cmdline is not running because we incorrectly implemented Gomega Match method 
Current Code: Match(actual interface{}) (success bool, err error)

The correct interface for Gomega Match is 
Match(actual interface{}) (success bool, message string, err error)

*source: http://onsi.github.io/gomega/#adding_your_own_matchers
