### PR TITLE
Added ramping example to ReadMe. Added error-checking for invalid input for -concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ There are three ways to run PAT locally. For all three ways, you must first:
 
     pat -concurrency=5 -iterations=1  # This will only spawn a single concurrent thread instead of the 5 you requested because you are only pushing a single application
 
+    pat -concurrency=1..5 -concurrency:timeBetweenSteps=10  -iterations=5 # This will ramp from 1 to 5 workers, adding a worker every 10 seconds.
+
     pat -silent  # If you don't want all the fancy output to be shown (results can be found in a CSV)
 
     pat -list-workloads  # Lists the available workloads

--- a/cmdline/cmdline.go
+++ b/cmdline/cmdline.go
@@ -46,7 +46,7 @@ func RunCommandLine() error {
 		return validateParameters(worker, func() error {
 			return store.WithStore(func(store Store) error {
 
-				parsedConcurrency := parseConcurrency(params.concurrency)
+				parsedConcurrency, err := parseConcurrency(params.concurrency)
 				parsedConcurrencyStepTime := parseConcurrencyStepTime(params.concurrencyStepTime)
 
 				lab := LaboratoryFactory(store)
@@ -64,19 +64,26 @@ func RunCommandLine() error {
 							params.iterations, parsedConcurrency, parsedConcurrencyStepTime, params.interval, params.stop, worker, params.workload)), handlers)
 
 				BlockExit()
-				return nil
+				return err
 			})
 		})
 	})
 }
 
-func parseConcurrency(concurrency string) []int {
+func parseConcurrency(concurrency string) ([]int, error) {
 	rawConcurrency := strings.SplitN(concurrency, "..", 2)
 	parsedConcurrency := make([]int, len(rawConcurrency))
 	for i, v := range rawConcurrency {
-		parsedConcurrency[i], _ = strconv.Atoi(v)
+		intV, err := strconv.Atoi(v)
+		if err != nil {
+			parsedConcurrency = []int{1}
+			return parsedConcurrency, err
+		} else {
+			parsedConcurrency[i] = intV
+		}
+
 	}
-	return parsedConcurrency
+	return parsedConcurrency, nil
 }
 
 func parseConcurrencyStepTime(concurrencyStepTime int) time.Duration {

--- a/cmdline/cmdline_test.go
+++ b/cmdline/cmdline_test.go
@@ -19,6 +19,7 @@ var _ = Describe("Cmdline", func() {
 		flags config.Config
 		args  []string
 		lab   *dummyLab
+		err   error
 	)
 
 	BeforeEach(func() {
@@ -43,7 +44,7 @@ var _ = Describe("Cmdline", func() {
 		flags.Parse(args)
 
 		BlockExit = func() {}
-		RunCommandLine()
+		err = RunCommandLine()
 	})
 
 	Describe("When -iterations is supplied", func() {
@@ -73,6 +74,16 @@ var _ = Describe("Cmdline", func() {
 
 		It("configures the experiment with the parameter", func() {
 			Ω(lab).Should(HaveBeenRunWith("concurrency", []int{1, 3}))
+		})
+	})
+
+	Describe("When -concurrency is supplied with an incorrectly formatted input", func() {
+		BeforeEach(func() {
+			args = []string{"-concurrency", "1-3"}
+		})
+
+		It("throws an error", func() {
+			Ω(err).ShouldNot(BeNil())
 		})
 	})
 


### PR DESCRIPTION
Quick touch up for PR #69. Added an example of how to use the ramping functionality to the readme. Also, added error checking for -concurrency as it is now parsed as in as a string, and thus errors won't be caught by the flag parsing library. 
