### PR TITLE
More intuiative and nicer workload input for user

### DIFF
--- a/ui/css/app.css
+++ b/ui/css/app.css
@@ -34,6 +34,15 @@ tr, td {
   box-sizing:border-box;
 }
 
+.inputCaption{
+  background: #ccc;
+  display: block;
+  padding: 2px 5px;
+  color: #999;
+  font-size: 10pt;
+  text-shadow: 0 1px 0 #eee;
+}
+
 .main-tooltip {
   position:absolute;
   right:15px;

--- a/ui/index.html
+++ b/ui/index.html
@@ -79,78 +79,78 @@ body { padding: 8px; }
     </div>
   </div>
 
-  <div class="modal" id="experimentPopup" tabindex="-1" role="dialog" data-dismiss="modal" aria-labelledby="experimentPopupLabel" aria-hidden="true" >
+  <div class="modal" id="experimentPopup" tabindex="-1" role="dialog" aria-labelledby="experimentPopupLabel" aria-hidden="true" >
     <div class="modal-dialog" style="width: 90%; max-width: 900px;">
       <div class="modal-content" style="background:rgba(255,255,255,0.75);">
         <div class="modal-header">
-          <button id="btnExperimentClose" type="button" class="close" aria-hidden="true">&times;</button>
+          <button id="btnExperimentClose" type="button" data-dismiss="modal" class="close" aria-hidden="true">&times;</button>
           <h4 class="modal-title">Experiment Configuration</h4>
         </div>
-      <div class="panel-body">
-        <form class="form-horizontal" role="form">          
-          <div class="form-group">
-            <label class="col-sm-3 control-label">Workload Items</label>
-            <div class="col-sm-6">
-              <!-- ko foreach: workloadModels.itemModel -->
-                <button type="button" class="btn btn-default" data-bind="html: html, click: click, attr: {id: 'workloadItem-' + name}"></button>
-              <!-- /ko -->​
+          
+        <div class="modal-body">
+          <form role="form">
+          <div style="width:70%; float:left">
+            <div class="form-group">
+              <label class="control-label inputCaption">Workload Items</label>
+              <div>
+                <!-- ko foreach: workloadModels.itemModel -->
+                  <button type="button" class="btn btn-default" style="margin:3px" data-bind="html: html, click: click, attr: {id: 'workloadItem-' + name}"></button>
+                <!-- /ko -->​
+              </div>
             </div>
-          </div>
-          <div class="form-group">
-            <label  class="col-sm-3 control-label">Selected Workload</label>
-            <div class="col-sm-6">
-              <!-- ko foreach: workloadModels.selectedModel -->
-                <button type="button" class="btn btn-link" data-bind="html: html, click: click"></button>
-              <!-- /ko -->​
-            </div>
-          </div>          
-          <div id="argumentList" class="form-group">
-            <label class="col-sm-3 control-label">Workload Arguments</label>
-            <div class="col-sm-6">
-              <div class="form-horizontal" role="form" data-bind="foreach: workloadModels.argumentModel">
+
+            <div class="form-group">
+              <label class="control-label inputCaption" data-bind="style: {display: workloadModels.shouldShowSelectedCaption()? 'block':'none'}">Selected Workload</label>
+              <div>
+                <!-- ko foreach: workloadModels.selectedModel -->
+                  <button type="button" class="btn btn-link" data-bind="html: html, click: click"></button>
+                <!-- /ko -->​
+              </div>
+            </div> 
+
+            <div id="argumentList" class="form-group">
+              <label class="control-label inputCaption" data-bind="style: {display: workloadModels.shouldShowArgumentCaption()? 'block':'none'}">Workload Arguments</label>            
+              <div role="form" data-bind="foreach: workloadModels.argumentModel">
                 <div class="form-group" data-bind="css: { 'has-error': errCheckFn }, style: {display: display}">
                   <label class="col-sm-4 control-label" data-bind="text: argName"></label>
                   <div class="col-sm-6">
                     <input type="text" class="form-control" data-bind="value: value">
                   </div>
                 </div>
-              </div>
-            </div>            
+              </div>            
+            </div>
+
           </div>
 
-          <div class="form-group" data-bind="css: { 'has-error': numIterationsHasError }">
-            <label for="inputIterations" class="col-sm-3 control-label">Iterations</label>
-            <div class="col-sm-6">
+          <div style="width:25%; float:right;">
+            <div class="form-group" data-bind="css: { 'has-error': numIterationsHasError }">
+              <label for="inputIterations" class="control-label inputCaption">Iterations</label>
               <input type="number" class="form-control" id="inputIterations" name="inputIterations" placeholder="1" data-bind="value: numIterations">
             </div>
-          </div>
-          <div class="form-group" data-bind="css: { 'has-error': numConcurrentHasError }">
-            <label for="inputConcurrency" class="col-sm-3 control-label">Concurrency</label>
-            <div class="col-sm-6">
+            <div class="form-group" data-bind="css: { 'has-error': numConcurrentHasError }">
+              <label for="inputConcurrency" class="control-label inputCaption">Concurrency</label>
               <input type="number" class="form-control" id="inputConcurrency" name="inputConcurrency" placeholder="1" data-bind="value: numConcurrent">
             </div>
-          </div>
-          <div class="form-group" data-bind="css: { 'has-error': numIntervalHasError }">
-            <label for="inputInterval" class="col-sm-3 control-label">Interval</label>
-            <div class="col-sm-6">
+            <div class="form-group" data-bind="css: { 'has-error': numIntervalHasError }">
+              <label for="inputInterval" class="control-label inputCaption">Interval</label>
               <input type="number" class="form-control" id="inputInterval" name="inputInterval" placeholder="0" data-bind="value: numInterval">
             </div>
-          </div>
-          <div class="form-group" data-bind="css: { 'has-error': numStopHasError }">
-            <label for="inputStop" class="col-sm-3 control-label">Stop</label>
-            <div class="col-sm-6">
+            <div class="form-group" data-bind="css: { 'has-error': numStopHasError }">
+              <label for="inputStop" class="control-label inputCaption">Stop</label>
               <input type="number" class="form-control" id="inputStop" name="inputStop" placeholder="0" data-bind="value: numStop">
             </div>
           </div>
-          <div class="form-group">
-            <div class="col-sm-offset-2 col-sm-10">
-              <button data-bind="click: start, enable: formHasNoErrors" id="startbtn" type="submit" data-dismiss="modal" class="btn btn-primary navbar-btn"><span class="glyphicon glyphicon-play"></span> Start Experiment</button>
-            </div>
-          </div>
-        </form>
+          </form>
+        </div> <!-- model body -->
+
+        <div style="clear:both"></div>
+        <hr>
+        <div style="text-align:right; margin:20px;">
+          <button data-bind="click: start, enable: formHasNoErrors" id="startbtn" type="submit" data-dismiss="modal" class="btn btn-primary"><span class="glyphicon glyphicon-play"></span> Start Experiment</button>
+        </div>
+
+      </div> <!-- model content -->
     </div>
-    </div>  
-  </div>
   </div>
 
   <div class="modal fade" id="historyPopup" tabindex="-1" role="dialog" aria-labelledby="historyPopupLabel" aria-hidden="true" >

--- a/ui/js/tests.js
+++ b/ui/js/tests.js
@@ -18,6 +18,34 @@ describe("Workload List", function(){
     }
   })
 
+  it("returns 'true' for showing selected workload caption if any workload is selected", function(){
+    expect(workloadList.shouldShowSelectedCaption() ).toBe(false)
+
+    var cmd = "dummy"
+    $("#workloadItems button:contains(" + cmd + ")").trigger("click") 
+    
+    expect(workloadList.shouldShowSelectedCaption() ).toBe(true)
+    expect(workloadList.shouldShowArgumentCaption() ).toBe(false)
+  })
+
+  it("returns 'false' for showing selected workload caption if all workload is removed", function(){    
+    var cmd = "dummy"
+    $("#workloadItems button:contains(" + cmd + ")").trigger("click") 
+    expect(workloadList.shouldShowSelectedCaption() ).toBe(true)
+    
+    $("#selectedList button:contains(" + cmd + ")").trigger("click") 
+    expect(workloadList.shouldShowArgumentCaption() ).toBe(false)    
+  })
+
+  it("returns 'true' for showing argument caption if any argument input is required", function(){
+    expect(workloadList.shouldShowArgumentCaption() ).toBe(false)
+
+    var cmd = "rest:target"
+    $("#workloadItems button:contains(" + cmd + ")").trigger("click") 
+    
+    expect(workloadList.shouldShowArgumentCaption() ).toBe(true)
+  })
+  
   it("removes a selected command when user click on the selected command button", function(){    
     var cmd = "rest:target"
 

--- a/ui/js/workloadModels.js
+++ b/ui/js/workloadModels.js
@@ -224,10 +224,27 @@ patWorkload = function(){
 	var selectedModel = ko.observableArray([])
 	var argumentModel = ko.observableArray([cfTarget, cfUser, cfPass]);
 
+	var showSelectedCaption = ko.computed(function(){
+		if (selectedModel().length > 0) {
+			return true
+		} else {
+			return false
+		}
+	})
+
+	var showArgumentCaption = ko.computed(function(){			
+		for (var i = 0; i < argumentModel().length; i ++) {
+			if (argumentModel()[i].display() != "none") return true
+		}
+		return false
+	})
+
 	return {
 		workloads: workloadStr,
 		itemModel: itemModel,
 		selectedModel: selectedModel,
+		shouldShowSelectedCaption: showSelectedCaption,
+		shouldShowArgumentCaption: showArgumentCaption,		
 		argumentModel: argumentModel,
 		cfTargetHasErr: cfTarget.errCheckFn,
 		cfUserHasErr: cfUser.errCheckFn,


### PR DESCRIPTION
Small update for:
- Dividing workload input (workload + arguments) and other inputs (iteration, concurrency interval etc ...) into left and right panels.
- Only shows the captions 'Selected Workload' and 'Argument Input' when necessary to avoid confusing users.
