### PR TITLE
Fixed error reporting to so errors actually show up

### DIFF
--- a/benchmarker/errors.go
+++ b/benchmarker/errors.go
@@ -1,5 +1,7 @@
 package benchmarker
 
+import "encoding/json"
+
 type EncodableError struct {
 	Message string
 }
@@ -14,4 +16,12 @@ func encodeError(err error) *EncodableError {
 	}
 
 	return &EncodableError{err.Error()}
+}
+
+func (e *EncodableError) MarshalJSON() ([]byte, error) {
+	return json.Marshal(e.Error())
+}
+
+func (e *EncodableError) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, e.Message)
 }

--- a/benchmarker/redis.go
+++ b/benchmarker/redis.go
@@ -39,7 +39,7 @@ func (rw rw) Time(workload string, workloadCtx context.Context) (result Iteratio
 		Reply:           "replies-" + guid.String(),
 		WorkloadContext: workloadCtx,
 	}
-	
+
 	var jsonRedisMsg []byte
 	var err error
 	jsonRedisMsg, err = json.Marshal(redisMsg)
@@ -101,7 +101,7 @@ func slaveLoop(conn redis.Conn, delegate Worker, handle string) {
 
 		if err == nil {
 
-			redisMsg.WorkloadContext = context.New()			
+			redisMsg.WorkloadContext = context.New()
 
 			json.Unmarshal([]byte(reply[1]), &redisMsg)
 

--- a/cmdline/display.go
+++ b/cmdline/display.go
@@ -40,7 +40,7 @@ func display(concurrency string, iterations int, interval int, stop int, concurr
 		fmt.Println("┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄")
 		if s.TotalErrors > 0 {
 			fmt.Printf("\nTotal errors: %d\n", s.TotalErrors)
-			fmt.Printf("Last error: %v\n", "")
+			fmt.Printf("Last error: %v\n", s.LastError)
 		}
 		fmt.Println()
 		fmt.Println("Type q <Enter> (or ctrl-c) to exit")

--- a/experiment/runner.go
+++ b/experiment/runner.go
@@ -3,6 +3,7 @@ package experiment
 import (
 	"math"
 	"time"
+
 	. "github.com/cloudfoundry-incubator/pat/benchmarker"
 	"github.com/cloudfoundry-incubator/pat/context"
 )
@@ -34,7 +35,7 @@ type Sample struct {
 	TotalErrors           int
 	TotalWorkers          int
 	LastResult            time.Duration
-	LastError             error
+	LastError             string
 	WorstResult           time.Duration
 	NinetyfifthPercentile time.Duration
 	WallTime              time.Duration
@@ -183,7 +184,7 @@ func (ex *SamplableExperiment) Sample() {
 	var iterations int64
 	var totalTime time.Duration
 	var avg time.Duration
-	var lastError error
+	var lastError string
 	var lastResult time.Duration
 	var totalErrors int
 	var workers int
@@ -235,7 +236,7 @@ func (ex *SamplableExperiment) Sample() {
 			}
 
 			if iteration.Error != nil {
-				lastError = iteration.Error
+				lastError = iteration.Error.Error()
 				totalErrors = totalErrors + 1
 			}
 		case w := <-ex.workers:

--- a/server/server.go
+++ b/server/server.go
@@ -160,14 +160,13 @@ func (ctx *serverContext) handlePush(w http.ResponseWriter, r *http.Request) (in
 func (ctx *serverContext) handleGetExperiment(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	name := mux.Vars(r)["name"]
 	data, err := ctx.lab.GetData(name)
-
 	if len(data) == 0 {
 		// Ensure empty array is encoded as [] rather than null
 		/// see https://groups.google.com/forum/#!topic/golang-nuts/gOHbOk8DsFw
 		data = []*Sample{}
 	}
-
 	return &listResponse{data}, err
+
 }
 
 func csvHandler(fn func(http.ResponseWriter, *http.Request) (interface{}, error)) http.HandlerFunc {

--- a/store/csv.go
+++ b/store/csv.go
@@ -69,7 +69,7 @@ func (self *csvFile) Write(samples <-chan *experiment.Sample) {
 	var body []string
 	w := csv.NewWriter(f)
 
-	header = []string{"Average", "TotalTime", "Total", "TotalErrors", "TotalWorkers", "LastResult", "WorstResult", "NinetyfifthPercentile", "WallTime", "Type"}
+	header = []string{"Average", "TotalTime", "Total", "TotalErrors", "LastError", "TotalWorkers", "LastResult", "WorstResult", "NinetyfifthPercentile", "WallTime", "Type"}
 	for _, k := range self.commands {
 		header = append(header, "Commands|"+k+"|Count",
 			"Commands|"+k+"|Throughput",
@@ -82,11 +82,11 @@ func (self *csvFile) Write(samples <-chan *experiment.Sample) {
 
 	for s := range samples {
 		if s.Type == experiment.ResultSample {
-
 			body = []string{strconv.Itoa(int(s.Average.Nanoseconds())),
 				strconv.Itoa(int(s.TotalTime.Nanoseconds())),
 				strconv.Itoa(int(s.Total)),
 				strconv.Itoa(int(s.TotalErrors)),
+				s.LastError,
 				strconv.Itoa(int(s.TotalWorkers)),
 				strconv.Itoa(int(s.LastResult.Nanoseconds())),
 				strconv.Itoa(int(s.WorstResult.Nanoseconds())),
@@ -141,11 +141,12 @@ func (self *csvFile) GetData() (samples []*experiment.Sample, err error) {
 			sample.TotalTime, err = duration(d[1])
 			sample.Total, err = i64(d[2])
 			sample.TotalErrors, err = strconv.Atoi(d[3])
-			sample.TotalWorkers, err = strconv.Atoi(d[4])
-			sample.LastResult, err = duration(d[5])
-			sample.WorstResult, err = duration(d[6])
-			sample.NinetyfifthPercentile, err = duration(d[7])
-			sample.WallTime, err = duration(d[8])
+			sample.LastError = d[4]
+			sample.TotalWorkers, err = strconv.Atoi(d[5])
+			sample.LastResult, err = duration(d[6])
+			sample.WorstResult, err = duration(d[7])
+			sample.NinetyfifthPercentile, err = duration(d[8])
+			sample.WallTime, err = duration(d[9])
 			sample.Type = experiment.ResultSample // this is the only type we currently persist
 
 			var cmdName string

--- a/store/csv_test.go
+++ b/store/csv_test.go
@@ -1,7 +1,6 @@
 package store_test
 
 import (
-	"errors"
 	"io/ioutil"
 	"os"
 	"path"
@@ -42,8 +41,8 @@ var _ = Describe("Csv Store", func() {
 			cmd := experiment.Command{1, 0.5, 2, 3, 4, 5}
 			commands["boo"] = cmd
 			write(writer, []*experiment.Sample{
-				&experiment.Sample{commands, 1, 2, 3, 4, 5, 6, nil, 7, 3, 8, experiment.ResultSample},
-				&experiment.Sample{commands, 9, 8, 7, 6, 5, 4, errors.New("foo"), 3, 7, 2, experiment.ResultSample},
+				&experiment.Sample{commands, 1, 2, 3, 4, 5, 6, "", 7, 3, 8, experiment.ResultSample},
+				&experiment.Sample{commands, 9, 8, 7, 6, 5, 4, "foo", 3, 7, 2, experiment.ResultSample},
 			})
 			files, err := ioutil.ReadDir(dir)
 			Ω(err).ShouldNot(HaveOccurred())
@@ -59,13 +58,9 @@ var _ = Describe("Csv Store", func() {
 			Ω(strings.Split(output, "\n")[2]).Should(ContainSubstring("9,8,7,6"))
 		})
 
-		It("Includes all fields, except LastError", func() {
+		It("Includes all fields", func() {
 			meta := reflect.ValueOf(experiment.Sample{}).Type()
 			for i := 0; i < meta.NumField(); i++ {
-				if meta.Field(i).Name == "LastError" {
-					continue
-				}
-
 				Ω(strings.Split(output, "\n")[0]).Should(ContainSubstring(meta.Field(i).Name))
 			}
 		})
@@ -76,30 +71,21 @@ var _ = Describe("Csv Store", func() {
 			samples, err := ex[0].GetData()
 			Ω(err).ShouldNot(HaveOccurred())
 
-			Ω(samples[0]).Should(Equal(&experiment.Sample{commands, 1, 2, 3, 4, 5, 6, nil, 7, 3, 8, experiment.ResultSample}))
-		})
-
-		It("Does not save error text, to avoid huge files", func() {
-			ex, err := store.LoadAll()
-			Ω(err).ShouldNot(HaveOccurred())
-			samples, err := ex[0].GetData()
-			Ω(err).ShouldNot(HaveOccurred())
-
-			Ω(samples[0].LastError).Should(BeNil())
+			Ω(samples[0]).Should(Equal(&experiment.Sample{commands, 1, 2, 3, 4, 5, 6, "", 7, 3, 8, experiment.ResultSample}))
 		})
 
 		It("Loads multiple CSVs from a directory, in order", func() {
 			foo := store.Writer("bar")
 			write(foo, []*experiment.Sample{
-				&experiment.Sample{nil, 1, 2, 3, 4, 5, 6, nil, 7, 3, 8, experiment.ResultSample},
-				&experiment.Sample{nil, 9, 8, 7, 6, 5, 4, errors.New("foo"), 3, 7, 2, experiment.ResultSample},
+				&experiment.Sample{nil, 1, 2, 3, 4, 5, 6, "", 7, 3, 8, experiment.ResultSample},
+				&experiment.Sample{nil, 9, 8, 7, 6, 5, 4, "foo", 3, 7, 2, experiment.ResultSample},
 			})
 
 			bar := store.Writer("baz")
 			write(bar, []*experiment.Sample{
-				&experiment.Sample{nil, 1, 2, 3, 4, 5, 6, nil, 7, 3, 8, experiment.ResultSample},
-				&experiment.Sample{nil, 1, 2, 3, 4, 5, 6, nil, 7, 3, 8, experiment.ResultSample},
-				&experiment.Sample{nil, 9, 8, 7, 6, 5, 4, errors.New("foo"), 3, 7, 2, experiment.ResultSample},
+				&experiment.Sample{nil, 1, 2, 3, 4, 5, 6, "", 7, 3, 8, experiment.ResultSample},
+				&experiment.Sample{nil, 1, 2, 3, 4, 5, 6, "", 7, 3, 8, experiment.ResultSample},
+				&experiment.Sample{nil, 9, 8, 7, 6, 5, 4, "foo", 3, 7, 2, experiment.ResultSample},
 			})
 
 			samples, err := store.LoadAll()

--- a/store/redis_test.go
+++ b/store/redis_test.go
@@ -1,7 +1,6 @@
 package store_test
 
 import (
-	"errors"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -41,20 +40,20 @@ var _ = Describe("Redis Store", func() {
 
 			writer := store.Writer("experiment-1")
 			write(writer, []*experiment.Sample{
-				&experiment.Sample{nil, 1, 2, 3, 4, 5, 6, nil, 7, 9, 8, experiment.ResultSample},
-				&experiment.Sample{nil, 9, 8, 7, 6, 5, 4, errors.New("foo"), 3, 1, 2, experiment.ResultSample},
+				&experiment.Sample{nil, 1, 2, 3, 4, 5, 6, "", 7, 9, 8, experiment.ResultSample},
+				&experiment.Sample{nil, 9, 8, 7, 6, 5, 4, "foo", 3, 1, 2, experiment.ResultSample},
 			})
 
 			writer = store.Writer("experiment-2")
 			write(writer, []*experiment.Sample{
-				&experiment.Sample{nil, 2, 2, 3, 4, 5, 6, nil, 7, 9, 8, experiment.ResultSample},
+				&experiment.Sample{nil, 2, 2, 3, 4, 5, 6, "", 7, 9, 8, experiment.ResultSample},
 			})
 
 			writer = store.Writer("experiment-3")
 			write(writer, []*experiment.Sample{
-				&experiment.Sample{nil, 1, 3, 3, 4, 5, 6, nil, 7, 9, 8, experiment.ResultSample},
-				&experiment.Sample{nil, 2, 3, 3, 4, 5, 6, nil, 7, 9, 8, experiment.ResultSample},
-				&experiment.Sample{nil, 9, 8, 7, 6, 5, 4, errors.New("foo"), 3, 1, 2, experiment.ResultSample},
+				&experiment.Sample{nil, 1, 3, 3, 4, 5, 6, "", 7, 9, 8, experiment.ResultSample},
+				&experiment.Sample{nil, 2, 3, 3, 4, 5, 6, "", 7, 9, 8, experiment.ResultSample},
+				&experiment.Sample{nil, 9, 8, 7, 6, 5, 4, "foo", 3, 1, 2, experiment.ResultSample},
 			})
 
 			writer = store.Writer("experiment-with-no-data")

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -31,7 +31,7 @@ pat.experiment = function(refreshRate) {
   exports.run = function() {
     exports.state("running")
     exports.data([])
-		$.post( "/experiments/", { "iterations": exports.config.iterations(), "concurrency": exports.config.concurrency(), "interval": exports.config.interval(), "stop": exports.config.stop(),  "workload": exports.config.cfWorkload(), "cfTarget":  exports.config.cfTarget(), "cfUsername":  exports.config.cfUsername(), "cfPassword":  exports.config.cfPassword() }, function(data) {  
+		$.post( "/experiments/", { "iterations": exports.config.iterations(), "concurrency": exports.config.concurrency(), "interval": exports.config.interval(), "stop": exports.config.stop(),  "workload": exports.config.cfWorkload(), "cfTarget":  exports.config.cfTarget(), "cfUsername":  exports.config.cfUsername(), "cfPassword":  exports.config.cfPassword() }, function(data) {
 			exports.url(data.Location)
 			exports.csvUrl(data.CsvLocation)
 			exports.refreshNow()
@@ -87,7 +87,7 @@ pat.experimentList = function() {
 
 ko.bindingHandlers.chart = {
   c: {},
-  init: function(element, valueAccessor) {    
+  init: function(element, valueAccessor) {
     ko.bindingHandlers.chart.b = d3_workload.init(element);
     ko.bindingHandlers.chart.t = d3_throughput.init(element);
   },
@@ -104,7 +104,7 @@ ko.bindingHandlers.chart = {
 }
 
 pat.view = function(experimentList, experiment) {
-  var self = this  
+  var self = this
 
   var dom = new DOM();
   d3_workload.changeState(dom.showGraph)
@@ -114,13 +114,13 @@ pat.view = function(experimentList, experiment) {
   this.throughputVisible = ko.observable(false)
 
   this.workloadModels = new patWorkload();
-  
+
   this.redirectTo = function(location) { window.location = location }
 
   this.start = function() { experiment.run() }
   this.stop = function() { alert("Not implemented") }
   this.downloadCsv = function() { self.redirectTo(experiment.csvUrl()) }
-  
+
   experiment.config.cfWorkload = this.workloadModels.workloads
   experiment.config.cfTarget = this.workloadModels.cfTarget
   experiment.config.cfUsername = this.workloadModels.cfUsername
@@ -138,10 +138,10 @@ pat.view = function(experimentList, experiment) {
   this.numIntervalHasError = ko.computed(function() { return experiment.config.interval() < 0 })
   this.numStop = experiment.config.stop
   this.numStopHasError = ko.computed(function() { return experiment.config.stop() < 0 })
-  this.formHasNoErrors = ko.computed(function() { return ! ( this.workloadModels.worklistHasError() | this.workloadModels.cfTargetHasErr() | this.workloadModels.cfUserHasErr() | this.workloadModels.cfPassHasErr() | this.numIterationsHasError() | this.numConcurrentHasError() | this.numIntervalHasError() | this.numStopHasError() ) }, this)  
+  this.formHasNoErrors = ko.computed(function() { return ! ( this.workloadModels.worklistHasError() | this.workloadModels.cfTargetHasErr() | this.workloadModels.cfUserHasErr() | this.workloadModels.cfPassHasErr() | this.numIterationsHasError() | this.numConcurrentHasError() | this.numIntervalHasError() | this.numStopHasError() ) }, this)
   this.previousExperiments = experimentList.experiments
   this.data = experiment.data
-  
+
   experiment.url.subscribe(function(url) {
     window.location.hash = "#" + url
   })
@@ -167,5 +167,5 @@ pat.view = function(experimentList, experiment) {
     self.throughputVisible(false)
     ob(true)
   }
-  
+
 }

--- a/ui/js/bar.js
+++ b/ui/js/bar.js
@@ -7,7 +7,7 @@ d3_workload = function() {
   var x, y, xAxis, yAxis, svg, outerBody, barCon;
 
   var d3Graph = document.createElement('div');
-  d3Graph.className = "workloadContainer";  
+  d3Graph.className = "workloadContainer";
   d3Graph.width = "100%";
   d3Graph.height = "100%";
 
@@ -39,7 +39,7 @@ d3_workload = function() {
     el.appendChild(d3Graph);
 
     svg = d3.select(d3Graph)
-      .append("svg")      
+      .append("svg")
         .attr("width", jqObj.width())
         .attr("height", jqObj.height())
         .attr("class", "workload")
@@ -47,7 +47,7 @@ d3_workload = function() {
         .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 
     outerBody = svg.append("g");
-    
+
     svg.append("defs").append("clipPath")
       .attr("id", "workloadclip")
     .append("rect")
@@ -72,7 +72,7 @@ d3_workload = function() {
       .attr("class", "y axis")
       .attr("transform", "translate(" + (svgWidth - 0) + ", 0)");
 
-    barCon = chartBody.append("g")    
+    barCon = chartBody.append("g")
       .attr("transform", "translate(0,0)");
 
     drawArea = barCon.node();
@@ -91,7 +91,7 @@ d3_workload = function() {
       .attr("x", svgWidth / 2)
       .attr("y", -10)
       .text("Experiment Duration (seconds)")
-      .attr("style", "text-anchor: middle; font-size: 15pt; fill: #888;");  
+      .attr("style", "text-anchor: middle; font-size: 15pt; fill: #888;");
 
   } //end initDOM
 
@@ -148,8 +148,8 @@ d3_workload = function() {
     outerBody.select(".x.axis").call(xAxis);
     outerBody.select(".y.axis").call(yAxis);
 
-    hightlightErrors();
-   
+    highlightErrors();
+
     bars.exit().remove();
     labels.exit().remove();
 
@@ -168,16 +168,16 @@ d3_workload = function() {
     }
   }
 
-  function hightlightErrors() {
+  function highlightErrors() {
     var errorCount = 0;
     var bars = d3.select(drawArea).selectAll("rect.bar");
     bars.each(function(d,i) {
       if (d.TotalErrors > errorCount) {
-        var bar = d3.select(this);     
+        var bar = d3.select(this);
         bar.classed("error", true)
           .attr("data-toggle","tooltip")
           .attr("title", "Error: " + d.LastError);
-          
+
         errorCount += 1;
         $(this).tooltip({
           "placement": "top",


### PR DESCRIPTION
Ok, this change includes a couple other quality-of-life improvements that I stumbled on while coding it up. Namely, the change to server_test.go to use TempDir() is necessary because the hardcoded temp file it was previously using was causing a test to fail due to lingering test files from old test runs that were in the old format. (also, it would most likely fail on a non-unix system). New version uses a system-safe method and now cleans up after itself. 
The change to server.go itself is because previously, the error was being upload as a Golang error object, which javascript doesn't know what to do with. I've created a generic method that takes a struct and converts it to a string/interface map, which should hopefully be generic enough to take anything you throw at it and convert it to something javascript can read. 

Bunch of gofmt changes to the files I touched. 
