### PR TITLE
fixed index error in percentile calculations fixed repeateveryuntil to be deterministc

### DIFF
--- a/benchmarker/benchmarker_test.go
+++ b/benchmarker/benchmarker_test.go
@@ -62,47 +62,55 @@ var _ = Describe("Benchmarker", func() {
 	})
 
 	Describe("RepeatEveryUntil", func() {
-		It("repeats a function at n seconds interval", func() {
+		It("repeats a function every interval seconds", func() {
 			start := time.Now()
 			var end time.Time
-			n := 2
-			Execute(RepeatEveryUntil(n, 3, func(context.Context) { end = time.Now() }, nil), workloadCtx)
+			interval := 2
+			Execute(RepeatEveryUntil(interval, 3, func(context.Context) { end = time.Now() }, nil), workloadCtx)
 			elapsed := end.Sub(start)
 			elapsed = (elapsed / time.Second)
-			Ω(int(elapsed)).Should(Equal(n))
+			Ω(int(elapsed)).Should(Equal(interval))
 		})
 
-		It("repeats a function at n seconds interval and stops at s second", func() {
+		It("repeats a function every interval seconds until stop seconds", func() {
 			var total int = 0
-			n := 2
-			s := 11
-			Execute(RepeatEveryUntil(n, s, func(context.Context) { total += 1 }, nil), workloadCtx)
-			Ω(total).Should(Equal((s / n) + 1))
+			interval := 2
+			stop := 11
+			Execute(RepeatEveryUntil(interval, stop, func(context.Context) { total += 1 }, nil), workloadCtx)
+			Ω(total).Should(Equal((stop / interval) + 1))
 		})
 
-		It("repeats a function at n seconds interval and stops when channel quit is set to true", func() {
+		It("repeats a function every interval seconds and stops when channel quit is set to true", func() {
 			quit := make(chan bool)
 			var total int = 0
-			n := 2
-			s := 11
-			stop := 5
-			time.AfterFunc(time.Duration(stop)*time.Second, func() { quit <- true })
-			Execute(RepeatEveryUntil(n, s, func(context.Context) { total += 1 }, quit), workloadCtx)
-			Ω(total).Should(Equal((stop / n) + 1))
+			interval := 2
+			stop := 11
+			quitTime := 5
+			time.AfterFunc(time.Duration(quitTime)*time.Second, func() { quit <- true })
+			Execute(RepeatEveryUntil(interval, stop, func(context.Context) { total += 1 }, quit), workloadCtx)
+			Ω(total).Should(Equal((quitTime / interval) + 1))
 		})
 
-		It("runs a function once if n = 0 or s = 0", func() {
+		It("runs a function once if interval = 0 or stop = 0", func() {
 			var total int = 0
-			n := 0
-			s := 1
-			Execute(RepeatEveryUntil(n, s, func(context.Context) { total += 1 }, nil), workloadCtx)
+			interval := 0
+			stop := 1
+			Execute(RepeatEveryUntil(interval, stop, func(context.Context) { total += 1 }, nil), workloadCtx)
 			Ω(total).Should(Equal(1))
 
 			total = 0
-			n = 3
-			s = 0
-			Execute(RepeatEveryUntil(n, s, func(context.Context) { total += 1 }, nil), workloadCtx)
+			interval = 3
+			stop = 0
+			Execute(RepeatEveryUntil(interval, stop, func(context.Context) { total += 1 }, nil), workloadCtx)
 			Ω(total).Should(Equal(1))
+		})
+
+		It("runs a function stop/interval + 1 times if s is a multiple of n", func() {
+			var total int = 0
+			interval := 2
+			stop := 10
+			Execute(RepeatEveryUntil(interval, stop, func(context.Context) { total += 1 }, nil), workloadCtx)
+			Ω(total).Should(Equal((stop / interval) + 1))
 		})
 	})
 

--- a/cmdline/cmdline.go
+++ b/cmdline/cmdline.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cloudfoundry-incubator/pat/context"
 	"github.com/cloudfoundry-incubator/pat/benchmarker"
 	"github.com/cloudfoundry-incubator/pat/config"
+	"github.com/cloudfoundry-incubator/pat/context"
 	. "github.com/cloudfoundry-incubator/pat/experiment"
 	. "github.com/cloudfoundry-incubator/pat/laboratory"
 	"github.com/cloudfoundry-incubator/pat/store"
@@ -35,8 +35,8 @@ func InitCommandLineFlags(config config.Config) {
 	config.BoolVar(&params.silent, "silent", false, "true to run the commands and print output the terminal")
 	config.StringVar(&params.output, "output", "", "if specified, writes benchmark results to a CSV file")
 	config.StringVar(&params.workload, "workload", "gcf:push", "a comma-separated list of operations a user should issue (use -list-workloads to see available workload options)")
-	config.IntVar(&params.interval, "interval", 0, "repeat a workload at n second interval, to be used with -stop")
-	config.IntVar(&params.stop, "stop", 0, "stop a repeating interval after n second, to be used with -interval")
+	config.IntVar(&params.interval, "interval", 0, "repeat a workload every n seconds, to be used with -stop")
+	config.IntVar(&params.stop, "stop", 0, "repeat a repeating interval until n seconds, to be used with -interval")
 	config.BoolVar(&params.listWorkloads, "list-workloads", false, "Lists the available workloads")
 	benchmarker.DescribeParameters(config)
 	store.DescribeParameters(config)

--- a/experiment/runner.go
+++ b/experiment/runner.go
@@ -3,9 +3,8 @@ package experiment
 import (
 	"math"
 	"time"
-
-	"github.com/cloudfoundry-incubator/pat/context"
 	. "github.com/cloudfoundry-incubator/pat/benchmarker"
+	"github.com/cloudfoundry-incubator/pat/context"
 )
 
 type SampleType int
@@ -118,7 +117,7 @@ func (config *RunnableExperiment) Run(tracker func(<-chan *Sample), workloadCtx 
 	done := make(chan bool)
 	maxIterations := config.Iterations
 	if config.Stop != 0 && config.Interval != 0 && config.Interval < config.Stop {
-		maxIterations *= config.Stop / config.Interval
+		maxIterations *= int(1 + (float64(config.Stop) / float64(config.Interval)))
 	}
 	sampler := config.samplerFactory(maxIterations, iteration, errors, workers, samples, quit)
 	go sampler.Sample()
@@ -219,7 +218,6 @@ func (ex *SamplableExperiment) Sample() {
 					percentile[i+1] = lastResult
 				}
 			}
-
 			ninetyfifthPercentile = percentile[percentileLength-int(math.Floor(float64(iterations)*.05+0.95))]
 
 			for _, step := range iteration.Steps {


### PR DESCRIPTION
There was an error in calculating the length of the array for calculating percentile when interval/stop aren't easily divisible. Fixed it so it should work with any (positive) numbers now.

There was another error in the RepeatEveryUntil method, namely there was a race condition between the interval and stop tickers that was causing the final workload that is supposed to occur when time=stop to only execute sometimes. Changed the method so it should always kick off the final iteration now. 
