### PR TITLE
Bug fix for multi credential

### DIFF
--- a/benchmarker/benchmarker.go
+++ b/benchmarker/benchmarker.go
@@ -92,13 +92,17 @@ func Execute(tasks <-chan func(context.Context), workloadCtx context.Context) {
 
 func ExecuteConcurrently(schedule <-chan int, tasks <-chan func(context.Context), workloadCtx context.Context) {
 	var wg sync.WaitGroup
+	indexCounter := 0
 
 	for increment := range schedule {
+
 		for i := 0; i < increment; i++ {
 			wg.Add(1)
 			go func(t <-chan func(context.Context), ctx context.Context) {
 				defer wg.Done()
 				for task := range t {
+					ctx.PutInt("iterationIndex", indexCounter)
+					indexCounter++
 					task(ctx)
 				}
 			}(tasks, workloadCtx.Clone())

--- a/cmdline/cmdline_test.go
+++ b/cmdline/cmdline_test.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cloudfoundry-incubator/pat/context"
 	"github.com/cloudfoundry-incubator/pat/benchmarker"
 	. "github.com/cloudfoundry-incubator/pat/cmdline"
 	"github.com/cloudfoundry-incubator/pat/config"
+	"github.com/cloudfoundry-incubator/pat/context"
 	"github.com/cloudfoundry-incubator/pat/experiment"
 	"github.com/cloudfoundry-incubator/pat/laboratory"
 	"github.com/cloudfoundry-incubator/pat/workloads"

--- a/cmdline/display.go
+++ b/cmdline/display.go
@@ -11,7 +11,7 @@ func display(concurrency string, iterations int, interval int, stop int, concurr
 	for s := range samples {
 		fmt.Print("\033[2J\033[;H")
 		fmt.Println("\x1b[32;1mCloud Foundry Performance Acceptance Tests\x1b[0m")
-		fmt.Printf("Test underway. Concurrency: \x1b[36m%v\x1b[0m  Concurrency:TimeBetwenSteps: \x1b[36m%v\x1b[0m Workload iterations: \x1b[36m%v\x1b[0m  Interval: \x1b[36m%v\x1b[0m  Stop: \x1b[36m%v\x1b[0m\n", 
+		fmt.Printf("Test underway. Concurrency: \x1b[36m%v\x1b[0m  Concurrency:TimeBetwenSteps: \x1b[36m%v\x1b[0m Workload iterations: \x1b[36m%v\x1b[0m  Interval: \x1b[36m%v\x1b[0m  Stop: \x1b[36m%v\x1b[0m\n",
 			concurrency, concurrencyStepTime, iterations, interval, stop)
 		fmt.Println("┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄\n")
 

--- a/workloads/rest.go
+++ b/workloads/rest.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cloudfoundry-incubator/pat/context"
 	"github.com/cloudfoundry-incubator/pat/config"
+	"github.com/cloudfoundry-incubator/pat/context"
 	"github.com/nu7hatch/gouuid"
 )
 
@@ -43,7 +43,7 @@ func (r *rest) DescribeParameters(config config.Config) {
 }
 
 func (r *rest) Target(ctx context.Context) error {
-	if _, exists := ctx.GetString("cfTarget"); r.target == "" && exists { 
+	if _, exists := ctx.GetString("cfTarget"); r.target == "" && exists {
 		r.target, _ = ctx.GetString("cfTarget")
 	}
 
@@ -57,9 +57,10 @@ func (r *rest) Target(ctx context.Context) error {
 
 func (r *rest) Login(ctx context.Context) error {
 	body := &LoginResponse{}
-	workerIndex, _ := ctx.GetInt("workerIndex")
-	return checkTargetted(ctx, func(loginEndpoint string, apiEndpoint string) error {		
-		return r.PostToUaaSuccessfully(fmt.Sprintf("%s/oauth/token", loginEndpoint), r.oauthInputs(r.credentialsForWorker(workerIndex)), body, func(reply Reply) error {
+
+	iterationIndex, _ := ctx.GetInt("iterationIndex")
+	return checkTargetted(ctx, func(loginEndpoint string, apiEndpoint string) error {
+		return r.PostToUaaSuccessfully(fmt.Sprintf("%s/oauth/token", loginEndpoint), r.oauthInputs(r.credentialsForWorker(iterationIndex)), body, func(reply Reply) error {
 			ctx.PutString("token", body.Token)
 			return r.targetSpace(ctx)
 		})
@@ -224,10 +225,10 @@ func (s SpaceResponse) SpaceExists() bool {
 	return len(s.Resources) > 0
 }
 
-func (r *rest) credentialsForWorker(workerIndex int) (string, string) {
+func (r *rest) credentialsForWorker(iterationIndex int) (string, string) {
 	var userList = strings.Split(r.username, ",")
 	var passList = strings.Split(r.password, ",")
-	return userList[workerIndex % len(userList)], passList[workerIndex % len(passList)]
+	return userList[iterationIndex%len(userList)], passList[iterationIndex%len(passList)]
 }
 
 func (r *rest) oauthInputs(username string, password string) url.Values {

--- a/workloads/rest_test.go
+++ b/workloads/rest_test.go
@@ -6,8 +6,8 @@ import (
 	"mime/multipart"
 	"net/url"
 
-	"github.com/cloudfoundry-incubator/pat/context"
 	"github.com/cloudfoundry-incubator/pat/config"
+	"github.com/cloudfoundry-incubator/pat/context"
 	. "github.com/cloudfoundry-incubator/pat/workloads"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -41,7 +41,7 @@ var _ = Describe("Rest", func() {
 			config.Parse(args)
 			args = []string{"-rest:target", "APISERVER"}
 			restContext = context.New()
-			restContext.PutInt("workerIndex", 0)
+			restContext.PutInt("iterationIndex", 0)
 
 			replies["APISERVER/v2/info"] = TargetResponse{"THELOGINSERVER/PATH"}
 		})
@@ -208,23 +208,23 @@ var _ = Describe("Rest", func() {
 						Ω(data.(url.Values)["password"]).Should(Equal([]string{"pass1"}))
 					})
 
-					It("uses different username and password with different workerIndex", func() {
-						restContext.PutInt("workerIndex", 0)
- 						rest.Login(restContext)
+					It("uses different username and password with different iterationIndex", func() {
+						restContext.PutInt("iterationIndex", 0)
+						rest.Login(restContext)
 						data := client.ShouldHaveBeenCalledWith("POST(uaa)", "THELOGINSERVER/PATH/oauth/token")
 						Ω(data.(url.Values)["username"]).Should(Equal([]string{"user1"}))
 						Ω(data.(url.Values)["password"]).Should(Equal([]string{"pass1"}))
 
-						restContext.PutInt("workerIndex", 2)
- 						rest.Login(restContext)
+						restContext.PutInt("iterationIndex", 2)
+						rest.Login(restContext)
 						data = client.ShouldHaveBeenCalledWith("POST(uaa)", "THELOGINSERVER/PATH/oauth/token")
 						Ω(data.(url.Values)["username"]).Should(Equal([]string{"user3"}))
 						Ω(data.(url.Values)["password"]).Should(Equal([]string{"pass1"}))
 					})
 
 					It("recycles the list of username and password when there are more workers than username", func() {
-						restContext.PutInt("workerIndex", 6)
- 						rest.Login(restContext)
+						restContext.PutInt("iterationIndex", 6)
+						rest.Login(restContext)
 						data := client.ShouldHaveBeenCalledWith("POST(uaa)", "THELOGINSERVER/PATH/oauth/token")
 						Ω(data.(url.Values)["username"]).Should(Equal([]string{"user1"}))
 						Ω(data.(url.Values)["password"]).Should(Equal([]string{"pass1"}))
@@ -246,19 +246,19 @@ var _ = Describe("Rest", func() {
 					})
 
 					It("re-uses the only avaiable password", func() {
-						restContext.PutInt("workerIndex", 0)
+						restContext.PutInt("iterationIndex", 0)
 						rest.Login(restContext)
 						data := client.ShouldHaveBeenCalledWith("POST(uaa)", "THELOGINSERVER/PATH/oauth/token")
 						Ω(data.(url.Values)["username"]).Should(Equal([]string{"user1"}))
 						Ω(data.(url.Values)["password"]).Should(Equal([]string{"pass1"}))
 
-						restContext.PutInt("workerIndex", 1)
+						restContext.PutInt("iterationIndex", 1)
 						rest.Login(restContext)
 						data = client.ShouldHaveBeenCalledWith("POST(uaa)", "THELOGINSERVER/PATH/oauth/token")
 						Ω(data.(url.Values)["username"]).Should(Equal([]string{"user2"}))
 						Ω(data.(url.Values)["password"]).Should(Equal([]string{"pass1"}))
 
-						restContext.PutInt("workerIndex", 2)
+						restContext.PutInt("iterationIndex", 2)
 						rest.Login(restContext)
 						data = client.ShouldHaveBeenCalledWith("POST(uaa)", "THELOGINSERVER/PATH/oauth/token")
 						Ω(data.(url.Values)["username"]).Should(Equal([]string{"user3"}))


### PR DESCRIPTION
Currently we don't fill the context map with workerIndex (renamed to iterationIndex), it is a bug introduced from PR #91, and we didn't have a test in ExecuteConcurrently() to make sure the index is populated so the bug slipped by the test.

Fixes:
- Populate index in ExecuteConcurrently(), renamed workerIndex to iterationIndex because the index is actually # of iteration
- Test to make sure ExecuteConcurrently() populates the context map with 'iterationIndex'
