### PR TITLE
Added ability to push arbitrary apps using the context map.

### DIFF
--- a/cmdline/cmdline.go
+++ b/cmdline/cmdline.go
@@ -17,6 +17,7 @@ import (
 )
 
 var params = struct {
+	app                 string
 	iterations          int
 	listWorkloads       bool
 	concurrency         string
@@ -32,6 +33,7 @@ var params = struct {
 }{}
 
 func InitCommandLineFlags(config config.Config) {
+	config.StringVar(&params.app, "app", "assets/dora", "filepath to app, defaults to provided dora in assets")
 	config.IntVar(&params.iterations, "iterations", 1, "number of pushes to attempt")
 	config.StringVar(&params.concurrency, "concurrency", "1", "number of workers to execute the workload in parallel, can be static or ramping up, i.e. 1..3")
 	config.IntVar(&params.concurrencyStepTime, "concurrency:timeBetweenSteps", 60, "seconds between adding additonal workers when ramping works up")
@@ -53,6 +55,7 @@ func RunCommandLine() error {
 
 	workloadContext := context.New()
 	workloads.PopulateRestContext(params.restTarget, params.restUser, params.restPass, params.restSpace, workloadContext)
+	workloads.PopulateAppContext(params.app, workloadContext)
 
 	return WithConfiguredWorkerAndSlaves(func(worker benchmarker.Worker) error {
 		return validateParameters(worker, func() error {

--- a/workloads/cf.go
+++ b/workloads/cf.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cloudfoundry-incubator/pat/context"
 	"github.com/nu7hatch/gouuid"
 	"github.com/onsi/ginkgo"
 	. "github.com/pivotal-cf-experimental/cf-test-helpers/cf"
@@ -39,10 +40,10 @@ func DummyWithErrors() error {
 	return nil
 }
 
-func Push() error {
+func Push(ctx context.Context) error {
 	guid, _ := uuid.NewV4()
-	pathToApp := path.Join("assets", "dora")
-	return expectCfToSay("App started", "push", "pats-"+guid.String(), "-m", "64M", "-p", pathToApp)
+	pathToApp, _ := ctx.GetString("app")
+	return expectCfToSay("App Started", "push", "pats-"+guid.String(), "-m", "64M", "-p", pathToApp)
 }
 
 func CopyAndReplaceText(srcDir string, dstDir string, searchText string, replaceText string) error {
@@ -74,9 +75,9 @@ func CopyAndReplaceText(srcDir string, dstDir string, searchText string, replace
 	})
 }
 
-func GenerateAndPush() error {
+func GenerateAndPush(ctx context.Context) error {
 	guid, _ := uuid.NewV4()
-	srcDir := path.Join("assets", "dora")
+	srcDir, _ := ctx.GetString("app")
 	rand.Seed(time.Now().UTC().UnixNano())
 	salt := strconv.FormatInt(rand.Int63(), 10)
 	dstDir := path.Join(os.TempDir(), salt)


### PR DESCRIPTION
Added ability to specify an arbitrary app to push. Use the new "-app" flag with a path to the directory of the app you wish to push. If app is left out, it defaults to the dora in it's own assets directory. 
