### PR TITLE
README.md - Repeated line removed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ application, see the instructions on "Running PAT as a Cloud Foundry App" below.
 
 5) See [CF CLI] (https://github.com/cloudfoundry/cli) for instructions on installing `cf`
 
-Note: It is important that `cf` is accessable on your `$PATH` if you intend to use any of the 'cf:' workloads (see [CF Cli](http://github.com/cloudfoundry/cli) for instructions on installing the cloudfoundry cli).
+Note: It is important that `cf` is accessable on your `$PATH` if you intend to use any of the 'cf:' workloads.
 
 Running PAT
 =================================


### PR DESCRIPTION
This line is repeating and so removed:

 5) See [CF CLI](https://github.com/cloudfoundry/cli) for instructions on installing `cf`
     see [CF Cli](http://github.com/cloudfoundry/cli) for instructions on installing the cloudfoundry cli)." 
