### PR TITLE
Fix issue: PAT panics if there are any unexpected files in output/csvs/ #114

### DIFF
--- a/store/csv.go
+++ b/store/csv.go
@@ -189,13 +189,17 @@ func (store *CsvStore) LoadAll() (samples []experiment.Experiment, err error) {
 	samples = make([]experiment.Experiment, 0)
 	for _, f := range files {
 		base := strings.Split(f.Name(), ".")[0]
-		name := strings.SplitN(base, "-", 2)[1]
-		if len(name) > 0 {
-			loaded, err := store.load(f.Name(), name)
-			if err == nil {
-				samples = append(samples, loaded)
+		// In the output dir if a file/directory does not have a '-' (was part of standard output file), then it ignores it. 
+		ret := strings.Contains(base, "-")
+		 if(ret) {
+			name := strings.SplitN(base, "-", 2)[1]
+			if len(name) > 0 {
+				loaded, err := store.load(f.Name(), name)
+				if err == nil {
+					samples = append(samples, loaded)
+				}
 			}
-		}
+		}	
 	}
 
 	return

--- a/store/csv.go
+++ b/store/csv.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"fmt"
 
 	"github.com/cloudfoundry-incubator/pat/experiment"
 	"github.com/cloudfoundry-incubator/pat/logs"
@@ -185,19 +186,36 @@ func (store *CsvStore) LoadAll() (samples []experiment.Experiment, err error) {
 	if err != nil {
 		return nil, err
 	}
+	
+	var err_string string
 
 	samples = make([]experiment.Experiment, 0)
 	for _, f := range files {
-		base := strings.Split(f.Name(), ".")[0]
-		name := strings.SplitN(base, "-", 2)[1]
-		if len(name) > 0 {
-			loaded, err := store.load(f.Name(), name)
-			if err == nil {
-				samples = append(samples, loaded)
-			}
-		}
-	}
+         	Iscsvfile := strings.Contains(f.Name(), ".csv")
+                if (Iscsvfile) {
+                        base := strings.Split(f.Name(), ".")[0]
+                        Isdash := strings.Contains(base, "-")
+                	var name string = ""
+                        if (Isdash) {
+                                name = strings.SplitN(base, "-", 2)[1]
+                                }
+                        if len(name) <= 0 {
+                                name = base
+                        }
+                        loaded, err := store.load(f.Name(), name)
+                        if err == nil {
+                                samples = append(samples, loaded)
+                        }
+                } else {
+                        err_string = err_string + "," + f.Name()
 
+                }
+
+        }
+        if len(err_string) > 0 {
+                return samples, fmt.Errorf("these files are ignored %s", err_string)
+        }
+	
 	return
 }
 

--- a/store/csv_test.go
+++ b/store/csv_test.go
@@ -98,6 +98,13 @@ var _ = Describe("Csv Store", func() {
 			Ω(data(samples[2].GetData())).Should(HaveLen(3))
 		})
 
+ 		It("Check CSVs files ", func() {
+                        os.Create(dir+"/wrong-file-format")
+                        _ , err := store.LoadAll()
+                        Ω(err).Should(HaveOccurred())
+                        Ω(err.Error()).To(Equal("these files are ignored ,wrong-file-format"))
+		})
+
 		PIt("Throws exception if header is not in correct order", func() {
 		})
 


### PR DESCRIPTION
PAT panics if there are any unexpected files in output/csvs. This is because PAT is looking for standard file format it those items. Added a fix to ignore those elements and avoid the panic. There can be custom file created there from "logging:file" parameter passed and so that check is not always applicable to all files.
