### PR TITLE
Fix issue: Setting a custom file name for output does nothing #115

### DIFF
--- a/logs/config.go
+++ b/logs/config.go
@@ -3,6 +3,7 @@ package logs
 import (
 	"os"
 	"strings"
+	"path/filepath"
 
 	"github.com/cloudfoundry-incubator/pat/config"
 	"github.com/cloudfoundry/gosteno"
@@ -19,6 +20,10 @@ func InitCommandLineFlags(flags config.Config) {
 }
 
 var initialized bool
+
+func GetPath() string{
+        return params.path
+}
 
 func NewLogger(name string) *gosteno.Logger {
 	if !initialized {
@@ -41,7 +46,14 @@ func initLogging() {
 
 	sinks := []gosteno.Sink{}
 	if params.path != "" {
-		sinks = append(sinks, NewFileSink(params.path))
+		ret := strings.Contains(params.path, "/")
+                if(ret) {
+                        ldir, lfile := filepath.Split(params.path)
+                        if(lfile != "") {
+				sinks = append(sinks, NewFileSink(params.path))
+                        } else {
+                        	sinks = append(sinks, NewIOSink(os.Stdout))
+                        }
 	} else {
 		sinks = append(sinks, NewIOSink(os.Stdout))
 	}

--- a/store/csv.go
+++ b/store/csv.go
@@ -40,6 +40,11 @@ func (store *CsvStore) load(filename string, guid string) (experiment.Experiment
 
 func (store *CsvStore) newCsvFile(guid string) *csvFile {
 	file := &csvFile{path.Join(store.dir, strconv.Itoa(int(time.Now().UnixNano()))+"-"+guid+".csv"), guid, nil}
+	// if output file is passed as argument, then overwrite the default format.
+	var lfile = logs.GetPath();
+        if (lfile != "") {
+        file = &csvFile{path.Join(store.dir,lfile), "", nil }
+        }
 	store.workloadList.DescribeWorkloads(file)
 	return file
 }


### PR DESCRIPTION
logging:file parameter passed was not taking as output file instead always PAT takes the default output file format always.  This fix will:
- Take the argument passed a output file and place it in the correct output dir.
- If file is passed as dir/file format it checks the format and process the file, else it used to create panic.
