### PR TITLE
Call gomega.RegisterFailHandler to connect to ginkgo

### DIFF
--- a/workloads/cf.go
+++ b/workloads/cf.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cloudfoundry-incubator/pat/context"
 	"github.com/nu7hatch/gouuid"
 	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	. "github.com/pivotal-cf-experimental/cf-test-helpers/cf"
 )
 
@@ -144,6 +145,7 @@ func GenerateAndPush(ctx context.Context) error {
 
 func expectCfToSay(expect string, args ...string) error {
 	var outBuffer bytes.Buffer
+	gomega.RegisterFailHandler(ginkgo.Fail)
 	oldWriter := ginkgo.GinkgoWriter
 	ginkgo.GinkgoWriter = bufio.NewWriter(&outBuffer)
 	cfOutBuffer := Cf(args...).Wait(10 * time.Minute).Out


### PR DESCRIPTION
We must connect gomega with ginkgo in cf tests that use them, to avoid
the following error:

```
panic: You are trying to make an assertion, but Gomega's fail handler is nil.
If you're using Ginkgo then you probably forgot to put your assertion in an It().
Alternatively, you may have forgotten to register a fail handler with
RegisterFailHandler() or RegisterTestingT().
```
